### PR TITLE
Added supression for warnings

### DIFF
--- a/drheader/core.py
+++ b/drheader/core.py
@@ -2,7 +2,8 @@ import json
 
 import requests
 import validators
-
+import urllib3
+urllib3.disable_warnings()
 from drheader.utils import load_rules
 
 


### PR DESCRIPTION
urllib3 will issue several different warnings based on the level of certificate verification support. Whilst you should validate all SSL certificates, for now, we want to ignore them as the tool could be used on test sites or internal ones.