### PR TITLE
- Added pipelines dependencies to requirements_dev.txt and removed fl…

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,13 +16,23 @@ jobs:
               with:
                  python-version: ${{ matrix.python-version }}
 
+            - name: Install dependencies
+              run: pip install -r requirements_dev.txt
+
             - name: Test with pytest
-              run: |
-                pip install --upgrade setuptools
-                python setup.py pytest --addopts --junitxml=${{ matrix.python-version }}.results.xml
-                
+              run: python setup.py pytest --addopts --junitxml=${{ matrix.python-version }}.results.xml
+
             - name: Upload Test results
               uses: actions/upload-artifact@master
               with:
                  name: Results - ${{ matrix.python-version }}
                  path: ${{ matrix.python-version }}.results.xml
+
+            - name: Flake8 styles
+              run: python -m flake8 drheader
+
+            - name: Bandit security scan
+              run: python -m bandit -r ./drheader
+
+            - name: Safety dependency scan
+              run: python -m safety check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,20 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install dependencies
+        run: pip install -r requirements_dev.txt
+
       - name: Test with pytest
-        run: |
-          pip install --upgrade setuptools==39.0.1
-          python setup.py test
+        run: python setup.py test
+
+      - name: Flake8 styles
+        run: python -m flake8 drheader
+
+      - name: Bandit security scan
+        run: python -m bandit -r ./drheader
+
+      - name: Safety dependency scan
+        run: python -m safety check
 
       - name: Make Wheel
         run: |

--- a/drheader/__init__.py
+++ b/drheader/__init__.py
@@ -4,4 +4,4 @@
 
 __version__ = '0.1.1'
 
-from drheader.core import Drheader
+from drheader.core import Drheader  # noqa

--- a/drheader/cli.py
+++ b/drheader/cli.py
@@ -45,7 +45,7 @@ def compare(file, json_output, debug, rule_file):
                 "url": "https://test.com",
                 "headers": {
                     "X-XSS-Protection": "1; mode=block",
-                    "Content-Security-Policy": "default-src 'none'; script-src 'self' unsafe-inline; object-src 'self';",
+                    "Content-Security-Policy": "default-src 'none'; script-src 'self' unsafe-inline; object-src 'self';"
                     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
                     "X-Frame-Options": "SAMEORIGIN",
                     "X-Content-Type-Options": "nosniff",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ Click>=7.0
 validators==0.13.0
 tabulate==0.8.3
 pyyaml==5.1.2
-setuptools>=39.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 bumpversion==0.5.3
 wheel==0.32.1
 watchdog==0.9.0
-flake8==3.5.0
 tox==3.5.2
 coverage==4.5.1
 Sphinx==1.8.1
@@ -9,3 +8,6 @@ twine==1.12.1
 pytest==3.8.2
 pytest-runner==4.2
 setuptools>=39.0.1
+bandit == 1.6.2
+flake8 == 3.6.0
+safety == 1.8.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ universal = 1
 
 [flake8]
 exclude = docs
+max-line-length = 120
 
 [aliases]
 # Define setup.py command aliases here


### PR DESCRIPTION
…ake8 3.5.0 (updated to 3.6.0)

- Removed setuptools from requirements.txt
- Added noqa tag to init.py
- Added pip install to pull_request.yml and removed pip install --upgrade setuptools
- Flake8, bandit and safety steps added to pull_request.yml
- Added pip install to release.yml and removed pip install --upgrade setuptools
- Flake8, bandit and safety steps added to release.yml
- Added flake8 rule to setup.cfg to set flake8 line length to 120 characters
- Fix flake8 issue in cli.py (120 chars length)