### PR TITLE
Verify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ At the same time, you can customize the headers sent by the request. For that, y
 
 As we continue development on drHEADer, we will further enhance this functionality. 
 
+#### Other `requests` arguments
+
+The _verify_ argument supported by ```requests``` can be included. The default value is set to `True`.
+
+    # create drheader instance
+    drheader_instance = Drheader(url="http://test.com", verify=False)
+
+Other arguments may be included in the future such as _timeout_, _allow_redirects_ or _proxies_.
+
 # How Do I Customise drHEADer Rules?
 
 DrHEADer relies on a yaml file that defines the policy it will use when auditing security headers. The file is located at `./drheader/rules.yml`, and you can customise it to fit your particular needs. Please follow this [link](RULES.md) if you want to know more.  

--- a/drheader/core.py
+++ b/drheader/core.py
@@ -25,7 +25,8 @@ class Drheader:
         headers=None,
         status_code=None,
         params=None,
-        request_headers={}
+        request_headers={},
+        verify=True
     ):
         """
         NOTE: at least one param required.
@@ -44,6 +45,8 @@ class Drheader:
         :type params: dict
         :param request_headers: Request headers
         :type request_headers: dict
+        :param verify: Verify the server's TLS certificate
+        :type verify: bool or str
         """
 
         self.status_code = status_code
@@ -57,14 +60,14 @@ class Drheader:
 
         if self.url and not self.headers:
             self.headers, self.status_code = self._get_headers(
-                url, method, params, request_headers
+                url, method, params, request_headers, verify
             )
 
         # self.headers_lower = dict((k.lower(), v.lower()) for k, v in self.headers.items())
         self.report = []
 
     @staticmethod
-    def _get_headers(url, method, params, request_headers):
+    def _get_headers(url, method, params, request_headers, verify):
         """
         Get headers for specified url.
 
@@ -76,13 +79,15 @@ class Drheader:
         :type params: dict
         :param request_headers: Request headers
         :type request_headers: dict
+        :param verify: Verify the server's TLS certificate
+        :type verify: bool or str
         :return: headers, status_code
         :rtype: dict, int
         """
 
         if validators.url(url):
             req_obj = getattr(requests, method.lower())
-            r = req_obj(url, data=params, headers=request_headers)
+            r = req_obj(url, data=params, headers=request_headers, verify=verify)
 
             headers = r.headers
             if len(r.raw.headers.getlist('Set-Cookie')) > 0:


### PR DESCRIPTION
Adding the possibility to include the _verify_ option in `requests` when getting headers.  
Other options may be included in the future such as _timeout_, _allow_redirects_ or _proxies_.