### PR TITLE
New feature to download custom rules from URI as per issue #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ There are a number of parameters you can specify during bulk scans, these are:
 | --json            | Output report as json                                  |
 | --debug           | Show error messages                                    |
 | --rules FILENAME  | Use custom rule set                                    |
+| --rules-uri URL   | Use custom rule set, to download from a remote server  |
 | --merge           | Merge custom rule set on top of default set            |
 | --help            | Show this message and exit                             |
 | --junit           | Creates a junit report in `./reports/junit.xml` folder |

--- a/drheader/cli.py
+++ b/drheader/cli.py
@@ -13,7 +13,7 @@ from tabulate import tabulate
 
 from drheader import Drheader
 from drheader.cli_utils import echo_bulk_report, file_junit_report
-from drheader.utils import load_rules
+from drheader.utils import load_rules, get_rules_from_uri
 
 
 @click.group()
@@ -31,8 +31,9 @@ def scan():
 @click.option('--json', 'json_output', help='Output report as json', is_flag=True)
 @click.option('--debug', help='Show error messages', is_flag=True)
 @click.option('--rules', 'rule_file', help='Use custom rule set', type=click.File())
+@click.option('--rules-uri', 'rule_uri', help='Use custom rule set, downloaded from URI')
 @click.option('--merge', help='Merge custom file rules, on top of default rules', is_flag=True)
-def compare(file, json_output, debug, rule_file, merge):
+def compare(file, json_output, debug, rule_file, rule_uri, merge):
     """
     If you have headers you would like to test with drheader, you can "compare" them with your ruleset this command.
 
@@ -90,6 +91,17 @@ def compare(file, json_output, debug, rule_file, merge):
     except Exception as e:
         raise click.ClickException(e)
 
+    if rule_uri and not rule_file:
+        if not validators.url(rule_uri):
+            raise click.ClickException(message='"{}" is not a valid URL.'.format(rule_uri))
+        try:
+            rule_file = get_rules_from_uri(rule_uri)
+        except Exception as e:
+            if debug:
+                raise click.ClickException(e)
+            else:
+                raise click.ClickException('No content retrieved from rules-uri.')
+
     rules = load_rules(rule_file, merge)
 
     for i in data:
@@ -106,9 +118,10 @@ def compare(file, json_output, debug, rule_file, merge):
 @click.option('--json', 'json_output', help='Output report as json', is_flag=True)
 @click.option('--debug', help='Show error messages', is_flag=True)
 @click.option('--rules', 'rule_file', help='Use custom rule set', type=click.File())
+@click.option('--rules-uri', 'rule_uri', help='Use custom rule set, downloaded from URI')
 @click.option('--merge', help='Merge custom file rules, on top of default rules', is_flag=True)
 @click.option('--junit', help='Produces a junit report with the result of the scan', is_flag=True)
-def single(target_url, json_output, debug, rule_file, merge, junit):
+def single(target_url, json_output, debug, rule_file, rule_uri, merge, junit):
     """
     Scan a single http(s) endpoint with drheader.
 
@@ -121,6 +134,17 @@ def single(target_url, json_output, debug, rule_file, merge, junit):
     logging.debug('Validating: {}'.format(target_url))
     if not validators.url(target_url):
         raise click.ClickException(message='"{}" is not a valid URL.'.format(target_url))
+
+    if rule_uri and not rule_file:
+        if not validators.url(rule_uri):
+            raise click.ClickException(message='"{}" is not a valid URL.'.format(rule_uri))
+        try:
+            rule_file = get_rules_from_uri(rule_uri)
+        except Exception as e:
+            if debug:
+                raise click.ClickException(e)
+            else:
+                raise click.ClickException('No content retrieved from rules-uri.')
 
     rules = load_rules(rule_file, merge)
 
@@ -169,8 +193,9 @@ def single(target_url, json_output, debug, rule_file, merge, junit):
 @click.option('--json', 'json_output', help='Output report as json', is_flag=True)
 @click.option('--debug', help='Show error messages', is_flag=True)
 @click.option('--rules', 'rule_file', help='Use custom rule set', type=click.File())
+@click.option('--rules-uri', 'rule_uri', help='Use custom rule set, downloaded from URI')
 @click.option('--merge', help='Merge custom file rules, on top of default rules', is_flag=True)
-def bulk(file, json_output, post, input_format, debug, rule_file, merge):
+def bulk(file, json_output, post, input_format, debug, rule_file, rule_uri, merge):
     """
     Scan multiple http(s) endpoints with drheader.
 
@@ -234,6 +259,17 @@ def bulk(file, json_output, post, input_format, debug, rule_file, merge):
             raise click.ClickException(e)
 
     logging.debug('Found {} URLs'.format(len(urls)))
+
+    if rule_uri and not rule_file:
+        if not validators.url(rule_uri):
+            raise click.ClickException(message='"{}" is not a valid URL.'.format(rule_uri))
+        try:
+            rule_file = get_rules_from_uri(rule_uri)
+        except Exception as e:
+            if debug:
+                raise click.ClickException(e)
+            else:
+                raise click.ClickException('No content retrieved from rules-uri.')
 
     rules = load_rules(rule_file, merge)
 

--- a/drheader/utils.py
+++ b/drheader/utils.py
@@ -4,7 +4,8 @@
 
 import logging
 import os
-
+import io
+import requests
 import yaml
 
 
@@ -61,3 +62,18 @@ def merge_rules(default_rules, custom_rules):
         default_rules['Headers'][rule] = custom_rules['Headers'][rule]
 
     return default_rules
+
+
+def get_rules_from_uri(URI):
+    """
+    Retrieves custom rule set from URL
+    :param URI: URL to your custom rules file
+    :type URI: uri
+    :return: rules file
+    :rtype: file
+    """
+    download = requests.get(URI)
+    if not download.content:
+        raise Exception('No content retrieved from {}'.format(URI))
+    file = io.BytesIO(download.content)
+    return file

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,4 @@ validators==0.14.0
 unittest2==1.1.0
 xmlunittest==0.5.0
 junit-xml==1.9
+responses==0.10.12

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,8 +6,9 @@
 import os
 import yaml
 import unittest2
+import responses
 
-from drheader.utils import load_rules
+from drheader.utils import load_rules, get_rules_from_uri
 
 
 class TestUtilsFunctions(unittest2.TestCase):
@@ -44,6 +45,19 @@ class TestUtilsFunctions(unittest2.TestCase):
     def test_load_rules_bad_parameter(self):
         with self.assertRaises(AttributeError):
             load_rules(2)
+
+    @responses.activate
+    def test_get_rules_from_uri_wrong_URI(self):
+        responses.add(responses.GET, 'http://mydomain.com/custom.yml', status=404)
+        with self.assertRaises(Exception):
+            get_rules_from_uri("http://mydomain.com/custom.yml")
+
+    @responses.activate
+    def test_get_rules_from_uri_good_URI(self):
+        responses.add(responses.GET, 'http://localhost:8080/custom.yml', json=self.custom_rules, status=200)
+        file = get_rules_from_uri("http://localhost:8080/custom.yml")
+        content = yaml.safe_load(file.read())
+        self.assertEqual(content, self.custom_rules)
 
 
 # start unittest2 to run these tests


### PR DESCRIPTION
## Proposed changes

Add a new option to download custom rules from a remote server.

## Type of change

New option added `--rules-uri `to provide a downloadable file from a remote server to be used as custom file. It will only apply this flag if NOT `--rules` flag is already provided. If `--rules cutomfile.yml` flag is enabled, then `--rules-uri` is ignored, and file to be used will be local _customfile.yml_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [x] Documentation Update
- [x] Test Update
- [ ] Rules Update 
- [ ] Other (please describe)

Please ensure your pull request adheres to the following guidelines:
- [x] A Github Issue that explains the work.
- [x] The changes are in a branch that is reasonably up to date
- [x] Tests are provided to reasonably cover new or altered functionality.
- [x] Documentation is provided for the new or altered functionality.
- [x] You have the legal right to give us this code.
- [x] You have adhered to the CoC

## Link to the github issue 

https://github.com/Santandersecurityresearch/DrHeader/issues/#80

## Tests you have added 

**test_utils.py**
- TestUtilsFunctions.test_get_rules_from_uri_wrong_URI
- TestUtilsFunctions.test_get_rules_from_uri_good_URI

## Tests you have altered
None

## Anything Else 
The --rules flag takes precedence, as described above.

Thanks for getting this far !
