### PR TITLE
Fixes for issue 85 - Release yaml modified

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     strategy:
         max-parallel: 4
@@ -46,6 +47,7 @@ jobs:
            python3 setup.py --version > version     
            
       - name: Create Release
+        id: create_release
         uses: actions/create-release@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #85 

Added condition to trigger only when a tag is created
Added id field to create release step, as it was referred during the upload asset step
