### PR TITLE
Replace nose with pytest

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,8 +21,8 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements_dev.txt
 
-      - name: Test with Nosetests
-        run: python -m nose --with-xunit --xunit-file=${{ matrix.python-version }}.results.xml
+      - name: Test with pytest
+        run: python -m pytest --junitxml ${{ matrix.python-version }}.results.xml
 
       - name: Upload Test results
         uses: actions/upload-artifact@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements_dev.txt
 
-      - name: Test with Nosetests
-        run: python -m nose --with-xunit --xunit-file=${{ matrix.python-version }}.results.xml
+      - name: Test with pytest
+        run: python -m pytest --junitxml ${{ matrix.python-version }}.results.xml
 
       - name: Flake8 styles
         run: python -m flake8 drheader

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,18 +1,18 @@
 # Releasing
 
-Our approach to releasing new versions is quite simple. A new version will be released everytime there's a push to master branch. 
+Our approach to releasing new versions is quite simple. A new version will be released everytime there's a push to master branch.
 
-We've managed to have all the process to bump version for next release in the different files fully automated by using [github actions](https://github.com/features/actions). 
+We've managed to have all the process to bump version for next release in the different files fully automated by using [GitHub Actions](https://github.com/features/actions).
 
-We currently have 2 github actions configured in this repo, which will be triggered when:
+We currently have 2 GitHub Actions configured in this repo, which will be triggered when:
 
 * There's a pull request.
-    * If the PR is to a non master branch, this action will run standard checks like nosetests, flake8, bandit and safety to ensure everything is good with the code.
+    * If the PR is to a non-master branch, this action will run standard checks like pytest, flake8, bandit and safety to ensure everything is good with the code.
     * If the PR is to the master branch, this action will run standard checks, automatically bump release version number in appropriate files and commit those changes to the pull request branch.
 * There are changes pushed to master branch.
     * This action will run standard checks, create the wheel, the release/tag using the version previously bumped and publish the artefact to Pypi
 
-To bump version in files prior to release, we use [bump2version](https://github.com/c4urself/bump2version). The configuration for it to know what is the current version, what files need to have the version bumped up and what is the next version is in `setup.cfg`. 
+To bump version in files prior to release, we use [bump2version](https://github.com/c4urself/bump2version). The configuration for it to know what is the current version, what files need to have the version bumped up and what is the next version is in `setup.cfg`.
 
 ```ini
 [bumpversion]
@@ -36,6 +36,6 @@ replace = __version__ = '{new_version}'
 ...
 ```
 
-With this configuration, we are specifying that only those three files need to have the version bumped before release. By default, `bump2version` bumps a minor version (ie . from 1.2.2 to 1.3.0), but if we want it to be a major version or a patch bump, we only need to specify the `new_version` attribute in the configuration with the version we want to use for the release. 
+With this configuration, we are specifying that only those three files need to have the version bumped before release. By default, `bump2version` bumps a minor version (ie . from 1.2.2 to 1.3.0), but if we want it to be a major version or a patch bump, we only need to specify the `new_version` attribute in the configuration with the version we want to use for the release.
 
-**Note**: Master and develop branches are protected. It means that we require commits to be pushed through pull requests, status checks to pass before merging and restrict who can push to those branches. We aimed to have the release process fully automated, but because issues described [here](https://github.community/t5/GitHub-Actions/How-to-push-to-protected-branches-in-a-GitHub-Action/td-p/29609) or [here](https://github.community/t5/GitHub-Actions/Automatic-version-update-in-protected-branch/m-p/56469#M9895) when using github actions for this, we decided that disabling this protection in **develop** branch just when a PR from develop to master is submitted would be a good approach for us, so that the action that bumps the versions and commits the changes back can complete successfuly. 
+**Note**: Master and develop branches are protected. It means that we require commits to be pushed through pull requests, status checks to pass before merging and restrict who can push to those branches. We aimed to have the release process fully automated, but because issues described [here](https://github.community/t5/GitHub-Actions/How-to-push-to-protected-branches-in-a-GitHub-Action/td-p/29609) or [here](https://github.community/t5/GitHub-Actions/Automatic-version-update-in-protected-branch/m-p/56469#M9895) when using GitHub Actions for this, we decided that disabling this protection in **develop** branch just when a PR from develop to master is submitted would be a good approach for us, so that the action that bumps the versions and commits the changes back can complete successfully.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,6 @@ setuptools>=39.0.1
 bandit==1.7.2
 flake8==4.0.1
 safety==1.10.3
-nose>=1.3.6
 validators>=0.14.0
 unittest2==1.1.0
 xmlunittest==0.5.0


### PR DESCRIPTION
## Proposed changes

Nose has been unmaintained for a long time.

It's also confusing the test utility method process_test for a test method - in the workflow runs, nose is running 64 tests, but there are only 59 test cases. The extra 5 tests are because it's treating the process_test method as a test case - once in the TestBase class, and twice in each of the TestDrHeader and TestRules classes (which both inherit from TestBase).

This PR replaces nose in the workflow runs with pytest, which is already being used in other places such as the makefile.

## Type of change

What types of changes do you want to introduce to DrHeader?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation Update
- [x] Test Update
- [ ] Rules Update 
- [ ] Other (please describe)

Please ensure your pull request adheres to the following guidelines:
- [ ] A Github Issue that explains the work.
- [ ] The changes are in a branch that is reasonably up to date
- [ ] Tests are provided to reasonably cover new or altered functionality.
- [ ] Documentation is provided for the new or altered functionality.
- [ ] You have the legal right to give us this code.
- [ ] You have adhered to the CoC

## Link to the github issue 

https://github.com/Santandersecurityresearch/DrHeader/issues/

## Tests you have added 

testclass.method_name()  

## Tests you have altered

testclass.method_name()

## Anything Else 


Thanks for getting this far !
