### PR TITLE
Refactoring

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,8 +21,8 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements_dev.txt
 
-      - name: Test with Nosetests
-        run: python -m nose --with-xunit --xunit-file=${{ matrix.python-version }}.results.xml
+      - name: Test with pytest
+        run: python -m pytest --junitxml ${{ matrix.python-version }}.results.xml
 
       - name: Upload Test results
         uses: actions/upload-artifact@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements_dev.txt
 
-      - name: Test with Nosetests
-        run: python -m nose --with-xunit --xunit-file=${{ matrix.python-version }}.results.xml
+      - name: Test with pytest
+        run: python -m pytest --junitxml ${{ matrix.python-version }}.results.xml
 
       - name: Flake8 styles
         run: python -m flake8 drheader

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include LICENSE
 include README.md
 include RULES.md
 include drheader/*.yml
+include drheader/resources/delimiters.json
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ It is also possible to call drHEADer from within an existing project, and this i
 from drheader import Drheader
 
 # create drheader instance
-drheader_instance = Drheader(headers={'X-XSS-Protection': '1; mode=block'}, status_code=200)
+drheader_instance = Drheader(headers={'X-XSS-Protection': '1; mode=block'})
 
 report = drheader_instance.analyze()
 print(report)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,18 +1,18 @@
 # Releasing
 
-Our approach to releasing new versions is quite simple. A new version will be released everytime there's a push to master branch. 
+Our approach to releasing new versions is quite simple. A new version will be released everytime there's a push to master branch.
 
-We've managed to have all the process to bump version for next release in the different files fully automated by using [github actions](https://github.com/features/actions). 
+We've managed to have all the process to bump version for next release in the different files fully automated by using [GitHub Actions](https://github.com/features/actions).
 
-We currently have 2 github actions configured in this repo, which will be triggered when:
+We currently have 2 GitHub Actions configured in this repo, which will be triggered when:
 
 * There's a pull request.
-    * If the PR is to a non master branch, this action will run standard checks like nosetests, flake8, bandit and safety to ensure everything is good with the code.
+    * If the PR is to a non-master branch, this action will run standard checks like pytest, flake8, bandit and safety to ensure everything is good with the code.
     * If the PR is to the master branch, this action will run standard checks, automatically bump release version number in appropriate files and commit those changes to the pull request branch.
 * There are changes pushed to master branch.
     * This action will run standard checks, create the wheel, the release/tag using the version previously bumped and publish the artefact to Pypi
 
-To bump version in files prior to release, we use [bump2version](https://github.com/c4urself/bump2version). The configuration for it to know what is the current version, what files need to have the version bumped up and what is the next version is in `setup.cfg`. 
+To bump version in files prior to release, we use [bump2version](https://github.com/c4urself/bump2version). The configuration for it to know what is the current version, what files need to have the version bumped up and what is the next version is in `setup.cfg`.
 
 ```ini
 [bumpversion]
@@ -36,6 +36,6 @@ replace = __version__ = '{new_version}'
 ...
 ```
 
-With this configuration, we are specifying that only those three files need to have the version bumped before release. By default, `bump2version` bumps a minor version (ie . from 1.2.2 to 1.3.0), but if we want it to be a major version or a patch bump, we only need to specify the `new_version` attribute in the configuration with the version we want to use for the release. 
+With this configuration, we are specifying that only those three files need to have the version bumped before release. By default, `bump2version` bumps a minor version (ie . from 1.2.2 to 1.3.0), but if we want it to be a major version or a patch bump, we only need to specify the `new_version` attribute in the configuration with the version we want to use for the release.
 
-**Note**: Master and develop branches are protected. It means that we require commits to be pushed through pull requests, status checks to pass before merging and restrict who can push to those branches. We aimed to have the release process fully automated, but because issues described [here](https://github.community/t5/GitHub-Actions/How-to-push-to-protected-branches-in-a-GitHub-Action/td-p/29609) or [here](https://github.community/t5/GitHub-Actions/Automatic-version-update-in-protected-branch/m-p/56469#M9895) when using github actions for this, we decided that disabling this protection in **develop** branch just when a PR from develop to master is submitted would be a good approach for us, so that the action that bumps the versions and commits the changes back can complete successfuly. 
+**Note**: Master and develop branches are protected. It means that we require commits to be pushed through pull requests, status checks to pass before merging and restrict who can push to those branches. We aimed to have the release process fully automated, but because issues described [here](https://github.community/t5/GitHub-Actions/How-to-push-to-protected-branches-in-a-GitHub-Action/td-p/29609) or [here](https://github.community/t5/GitHub-Actions/Automatic-version-update-in-protected-branch/m-p/56469#M9895) when using GitHub Actions for this, we decided that disabling this protection in **develop** branch just when a PR from develop to master is submitted would be a good approach for us, so that the action that bumps the versions and commits the changes back can complete successfully.

--- a/RULES.md
+++ b/RULES.md
@@ -1,96 +1,263 @@
 # Introduction
+This document describes the format of the `rules.yml` file, which defines the policy drHEADer uses to audit your
+security headers. It also documents how to make changes to it so that you can configure your custom policy based on
+your specific requirements.
 
-This document describes the format of the `rules.yml` file. This file defines the policy drHEADer relies on to audit security headers. It also documents how to make changes to it so that you can configure your custom policy based on your particular requirements.
+## Contents
+* [Sample Policy](#sample-policy)
+* [File Structure](#file-structure)
+  * [Expected and Disallowed Values](#expected-and-disallowed-values)
+  * [Validation Order](#validation-order)
+  * [Permissible Values](#permissible-values)
+  * [Validating Policy Headers](#validating-policy-headers)
+  * [Validating Directives](#validating-directives)
+  * [Validating Cookies](#validating-cookies)
+  * [Validating Custom Headers](#validating-custom-headers)
+* [Example Use Cases](#example-use-cases)
+  * [Hardening the CSP](#hardening-the-csp)
+  * [Securing Cookies](#securing-cookies)
+  * [Preventing Caching](#preventing-caching)
+  * [Enforcing Cross-Origin Isolation](#enforcing-cross-origin-isolation)
 
-# File Format
-
-drHEADer policy is a yaml file, which is a human-readable format commonly used for configuration files. See a yaml sample drHEADer policy below:
-
+## Sample Policy
+drHEADer policy is defined in a yaml file. An example policy is given below:
 ```yaml
 Headers:
-  X-Frame-Options:
-    Required: True
-    Enforce: True
-    Value:
-    - SAMEORIGIN
-    - DENY
-    Severity:
-  X-XSS-Protection:
-    Required: True
-    Enforce: True
-    Value:
-    - 1; mode=block
-    Severity:
-  Server:
-    Required: False
-    Enforce: False
-    Value:
-    Severity:
-  Content-Security-Policy:
-    Required: True
-    Enforce: False
-    Value:
-    Must-Contain-One:
-    - default-src 'none'
-    - default-src 'self'
-    Must-Avoid:
-    - unsafe-inline
-    - unsafe-eval
-    Directives:
-      script-src:
-        Required: True
-        Enforce: True
-        Value:
-        - self
-      style-src:
-        Required: True
-        Enforce: False
-        Value:
-        Must-Avoid:
-        - http://www.example.com
-    Severity:
-  Set-Cookie:
-    Required: Optional
-    Enforce: False
-    Value:
-    Must-Contain:
-    - HttpOnly
-    - Secure
-    Severity:
   Cache-Control:
     Required: True
-    Enforce: True
-    Delimiter: ','
     Value:
-    - no-cache, no-store, must-revalidate
-    Severity:
+      - no-store
+      - max-age=0
+  Content-Security-Policy:
+    Required: True
+    Must-Avoid:
+        - block-all-mixed-content
+        - referrer
+        - unsafe-inline
+        - unsafe-eval
+    Directives:
+      Default-Src:
+        Required: True
+        Value-One-Of:
+          - none
+          - self
+        Severity: Critical
+  Server:
+    Required: False
+    Severity: Warning
+  Set-Cookie:
+    Required: Optional
+    Must-Contain:
+      - HttpOnly
+      - Secure
+    Must-Contain-One:
+      - Expires
+      - Max-Age
+  X-Frame-Options:
+    Required: True
+    Value-One-Of:
+      - DENY
+      - SAMEORIGIN
+  X-XSS-Protection:
+    Required: True
+    Value: 0
 ```
 
-# File Structure
+## File Structure
+The yaml file structure for drHEADer is described below. All elements are case-insensitive, and all checks against
+expected and disallowed values are case-insensitive.
 
-The yaml file structure for drHEADwe is as follows:
+* There must always be a root element `headers`
+* Inside the root element, there can be as many elements as headers you want to audit (e.g. Content-Security-Policy,
+Set-Cookie)
 
-* There must always be a root element with name 'Headers:'
-* Inside the root element, there must be as many elements as headers you want drHEADer to audit (ie: Content-Security-Policy, Set-Cookie, etc.).
-* Within each header, rules can be set for individual directives (directives are only applicable if they are set using a key-value format, such as for those in the Content-Security-Policy).
-  The rules for the directives must be defined under a root element 'Directives' under the relevant header
-* For each of these elements (or security headers to audit), the following flags can be set based on the specific requirements for that header:
-    * Required:
-        * 'True' if header is required to be present in the HTTP response
-        * 'False' if header is required not to be present in the HTTP response
-        * 'Optional' if header can be present in the HTTP response but is not mandatory
-    * Enforce:
-        * 'True' if the policy enforces a value for that header (full match)
-        * 'False' if the policy does not enforce a value for that header
-    * Value:
-        * It must be empty if 'Enforce' is set to False, otherwise
-        * It must be set to a list of values that would be accepted for that header. The validation will be successful if there is a full match (value in header matches with value in policy) with one of the values defined
-    * Delimiter: To be used when a header is enforced and the value specified contains multiple values that would be valid in any order (see example for Cache-Control). Default delimiter is ';'.
-    * Must-Contain: To be used when 'Required' is set to True or Optional and 'Enforce' is set to False.
-        * It can be set to a list of values that should be part of the header value. The validation will be successful if all values specified are found in the value set for that header (ie: for set-cookie the policy specifies that httponly AND secure should be part of the header value)
-    * Must-Contain-One: To be used when 'Required' is set to True or Optional and 'Enforce' is set to False.
-        * It can be set to a list of values where at least one should be part of the header. The validation will be successful if at least one value is found in the value set for that header (ie: for Content-Security-Policy the policy specifies that either "default-src 'none'" OR "default-src 'self'" should be part of the header value)
-    * Must-Avoid: To be used when 'Required' is set to True or Optional and 'Enforce' is set to False.
-        * It can be set to a list of values that should not be part of the header. The validation will be successful if none of the values are found in the value set for that header (ie: for Content-Security-Policy the policy specifies that "unsafe-inline" AND "unsafe-eval" should not be part of the header value)
-    * Severity (Optional): Severity of rule if missing.
-      * It can be high, medium or low.
+* Each header must specify whether the header is required via the `required` element. It can take the following values:
+  * `True`: The item must be present in the HTTP response
+  * `False`: The item must not be present in the HTTP response
+  * `Optional`: The header may be present in the HTTP response, but it is not mandatory
+
+* For items that are set as required or optional, the following additional rules may also be set. The checks will only
+run if the item is present in the HTTP response:
+  * `Value`: The item value must match the expected value(s)
+  * `Value-One-Of`: The item value must match exactly one of the expected values
+  * `Must-Avoid`: The item value must not contain any of the disallowed values
+  * `Must-Contain`: The item value must contain all the expected values
+  * `Must-Contain-One`: The item value must contain at least one of the expected values
+
+* You can override the default severity for an item by providing a custom severity in the `severity` element
+
+Within each header element, rules can be set for individual directives via the `directives` element. There can be as
+many directive elements as directives you want to audit (e.g. default-src, script-src). The same validations
+as above are available for individual directives
+
+### Expected and Disallowed Values
+For elements that define expected or disallowed values, those values can be given either as a list or a string. The two
+elements shown below are equivalent:
+```yaml
+Value:
+  - max-age=31536000
+  - includeSubDomains
+```
+```yaml
+Value: max-age=31536000; includeSubDomains
+```
+If given as a string, individual items must be separated with the correct item delimiter for the header or directive
+being evaluated. Therefore, for expected or disallowed values that specify multiple items, giving them as a list is
+generally preferred. For values that specify only a single item, a string is preferred for its simpler syntax.
+
+#### Validation Order
+Order is not preserved when validating. That is, both values shown below are valid for the above rule:
+```json
+{"Strict-Transport-Security": "max-age=31536000; includeSubDomains"}
+```
+```json
+{"Strict-Transport-Security": "includeSubDomains; max-age=31536000"}
+```
+
+#### Permissible Values
+For must-avoid, must-contain and must-contain-one checks, the expected or disallowed values can take a number of
+different formats to cover various avoid and contain scenarios that you might want to enforce:
+* Enforce or disallow standalone directives or values:
+```yaml
+Must-Contain: no-store
+```
+* Enforce or disallow entire key-value directives:
+```yaml
+Must-Contain: max-age=0
+```
+* Enforce or disallow specific keys for key-value directives, without stipulating the value:
+```yaml
+Must-Contain: max-age
+```
+The validations will match the expected or disallowed values against the whole item value (standalone directive/value,
+entire key-value directive, or key for key-value directive).
+
+### Validating Policy Headers
+Policy headers are those that generally follow the syntax `<policy-directive>; <policy-directive>` where
+`<policy-directive>` consists of `<directive> <value>` and `<value>` can consist of multiple items and keywords.
+Currently, this covers `Content-Security-Policy` and `Feature-Policy`.
+
+The quotation marks around keywords such as 'none', 'self' and 'unsafe-inline' in such policy headers must not be
+included in expected or disallowed values. The quotation marks are stripped from these values in HTTP responses before
+they are compared to the expected and disallowed values.
+<br />
+
+In addition to the formats described above, for policy headers, you can also define disallowed values in must-avoid
+checks that will be searched for in the values of all key-value directives. The below will report back all directives in
+the CSP that contain `unsafe-eval` or `unsafe-inline` as non-compliant:
+```yaml
+Content-Security-Policy:
+    Required: True
+    Must-Avoid:
+      - unsafe-eval
+      - unsafe-inline
+```
+
+### Validating Directives
+The mechanism for validating directives is the same as that for validating headers, and all the same validations are
+available. You can use it to validate any directive that is declared in a key-value format for any header. Each
+directive to be audited needs to be specified as an element under the `directives` element:
+```yaml
+Content-Security-Policy:
+  Required: True
+  Directives:
+    Default-Src:
+      Required: True
+      Value-One-Of:
+        - none
+        - self
+    Style-Src:
+      Required: True
+      Must-Contain: https://stylesheet-url.com
+```
+
+Note that if you want to enforce exists or not-exists validations for a directive, without enforcing any validations on
+its value, it is generally simpler to do so using contain and avoid validations respectively at the header level:
+```yaml
+Content-Security-Policy:
+  Required: True
+  Must-Contain:
+    - default-src
+  Must-Avoid:
+    - frame-src
+```
+
+### Validating Cookies
+Cookies validations are defined in the `set-cookie` element. The validations will run against all the cookies in the
+HTTP response. It is currently not possible to specify a validation to run only against a specific cookie in a response
+that returns multiple cookies.
+
+### Validating Custom Headers
+You can include custom headers for validation, and run the same validations on them, as you would any standard headers.
+If providing multiple expected or disallowed values for value, must-avoid, must-contain or must-contain-one checks, you
+need to specify the relevant delimiters in the `item-delimiter`, `key-delimiter` and `value-delimiter` elements:
+```yaml
+X-Custom-Header:
+  Required: True
+  Must-Contain:
+    - item_value_1
+    - item_value_2
+  Item-Delimiter: ;
+  Key-Delimiter: =
+  Value-Delimiter: ,
+```
+For example, the above rule would identify the directives `item_1 = value_1, value_2`, `item_2 = value_1` and `item_3`
+from the header given below:
+```json
+{"X-Custom-Header": "item_1 = value_1, value_2; item_2 = value_1; item_3"}
+```
+If the directives are not declared in a key-value format, or the value does not support multiple items, you can omit the
+`key-delimiter` and `value-delimiter` elements respectively.
+
+## Example Use Cases
+### Hardening the CSP
+```yaml
+Content-Security-Policy:
+    Required: True
+    Must-Avoid:
+        - unsafe-inline
+        - unsafe-eval
+        - unsafe-hashes
+    Directives:
+      Default-Src:
+        Required: True
+        Must-Contain: 'https:'
+      Script-Src:
+        Required: True
+        Value: self
+```
+
+### Securing Cookies
+```yaml
+Set-Cookie:
+  Required: Optional
+  Must-Contain:
+    - HttpOnly
+    - SameSite=Strict
+    - Secure
+  Must-Contain-One:
+    - Max-Age
+    - Expires
+```
+
+### Preventing Caching
+```yaml
+Cache-Control:
+  Required: True
+  Value:
+    - no-store
+    - max-age=0
+Pragma:
+  Required: True
+  Value: no-cache
+```
+
+### Enforcing Cross-Origin Isolation
+```yaml
+Cross-Origin-Embedder-Policy:
+  Required: True
+  Value: require-corp
+Cross-Origin-Opener-Policy:
+  Required: True
+  Value: same-origin
+```

--- a/drheader/cli.py
+++ b/drheader/cli.py
@@ -130,8 +130,8 @@ def compare(file, json_output, debug, rule_file, rule_uri, merge):
         logging.debug('Analysing : {}'.format(i['url']))
         drheader_instance = Drheader(url=i['url'], headers=i['headers'])
         drheader_instance.analyze(rules)
-        audit.append({'url': i['url'], 'report': drheader_instance.report})
-        if drheader_instance.report:
+        audit.append({'url': i['url'], 'report': drheader_instance.reporter.report})
+        if drheader_instance.reporter.report:
             exit_code = EXIT_CODE_FAILURE
 
     echo_bulk_report(audit, json_output)
@@ -192,25 +192,25 @@ def single(ctx, target_url, json_output, debug, rule_file, rule_uri, merge, juni
         else:
             raise click.ClickException('Failed to analyze headers.')
 
-    if drheader_instance.report:
+    if drheader_instance.reporter.report:
         exit_code = EXIT_CODE_FAILURE
 
     if json_output:
-        click.echo(json.dumps(drheader_instance.report))
+        click.echo(json.dumps(drheader_instance.reporter.report))
     else:
         click.echo()
-        if not drheader_instance.report:
+        if not drheader_instance.reporter.report:
             click.echo('No issues found!')
         else:
-            click.echo('{0} issues found'.format(len(drheader_instance.report)))
-            for i in drheader_instance.report:
+            click.echo('{0} issues found'.format(len(drheader_instance.reporter.report)))
+            for i in drheader_instance.reporter.report:
                 values = []
                 for k, v in i.items():
                     values.append([k, v])
                 click.echo('----')
                 click.echo(tabulate(values, tablefmt="presto"))
     if junit:
-        file_junit_report(rules, drheader_instance.report)
+        file_junit_report(rules, drheader_instance.reporter.report)
     sys.exit(exit_code)
 
 
@@ -308,8 +308,8 @@ def bulk(ctx, file, json_output, input_format, debug, rule_file, rule_uri, merge
             url=v['url'], params=v.get('params', None), verify=ctx.obj['verify'])
         logging.debug('Analysing: {}...'.format(v))
         drheader_instance.analyze(rules)
-        audit.append({'url': v['url'], 'report': drheader_instance.report})
-        if drheader_instance.report:
+        audit.append({'url': v['url'], 'report': drheader_instance.reporter.report})
+        if drheader_instance.reporter.report:
             exit_code = EXIT_CODE_FAILURE
 
     echo_bulk_report(audit, json_output)

--- a/drheader/core.py
+++ b/drheader/core.py
@@ -4,367 +4,119 @@ import requests
 import validators
 from requests.structures import CaseInsensitiveDict
 
-from drheader.utils import load_rules, _to_dict
+from drheader.report import Reporter
+from drheader.utils import load_rules, parse_policy
+from drheader.validator import DELIMITERS, validate_exists, validate_not_exists, validate_must_avoid, \
+    validate_must_contain, validate_must_contain_one, validate_value, validate_value_one_of
 
 
 class Drheader:
-    """
-    Core functionality for DrHeader. This is where the magic happens
-    """
-    error_types = {
-        1: 'Header not included in response',
-        2: 'Header should not be returned',
-        3: 'Value does not match security policy',
-        4: 'Must-Contain directive missed',
-        5: 'Must-Avoid directive included',
-        6: 'Must-Contain-One directive missed',
-        7: 'Directive not included in response',
-        8: 'Directive should not be returned'
-    }
 
-    def __init__(
-        self,
-        url=None,
-        method="GET",
-        headers=None,
-        status_code=None,
-        params=None,
-        request_headers=None,
-        verify=True
-    ):
+    def __init__(self, headers=None, url=None, method='get', params=None, request_headers=None, verify=True):
         """
-        NOTE: at least one param required.
+        Initialise a Drheader instance
+        :param dict headers: The headers to analyse
+        :param str url: The URL from which to retrieve the headers for analysis
+        :param str method: The HTTP method to use to retrieve the headers for analysis
+        :param dict params: Any request parameters to send when retrieving the headers for analysis
+        :param dict request_headers: Any request headers to send when retrieving the headers for analysis
+        :param bool verify: A flag to verify the server's TLS certificate
+        """
+        if not headers:
+            if not url:
+                raise ValueError("Nothing provided for analysis. Either 'headers' or 'url' must be defined")
+            else:
+                headers = self._get_headers(url, method, params, request_headers, verify)
 
-        :param url: (optional) URL of target
-        :type url: str
-        :param method: (optional) Method to use when doing the request
-        :type method: str
-        :param headers: (optional) Override headers
-        :type headers: dict
-        :param status_code: Override status code
-        :type status_code: int
-        :param params: Request params
-        :type params: dict
-        :param request_headers: Request headers
-        :type request_headers: dict
-        :param verify: Verify the server's TLS certificate
-        :type verify: bool or str
-        """
-        if request_headers is None:
-            request_headers = {}
         if isinstance(headers, str):
-            headers = json.loads(headers)
-        elif url and not headers:
-            headers, status_code = self._get_headers(url, method, params, request_headers, verify)
-
-        self.status_code = status_code
-        self.headers = CaseInsensitiveDict(headers)
-        self.anomalies = []
-        self.url = url
-        self.delimiter = ';'
-        self.report = []
-
-    @staticmethod
-    def _get_headers(url, method, params, request_headers, verify):
-        """
-        Get headers for specified url.
-
-        :param url: URL of target
-        :type url: str
-        :param method: (optional) Method to use when doing the request
-        :type method: str
-        :param params: Request params
-        :type params: dict
-        :param request_headers: Request headers
-        :type request_headers: dict
-        :param verify: Verify the server's TLS certificate
-        :type verify: bool or str
-        :return: headers, status_code
-        :rtype: dict, int
-        """
-
-        if validators.url(url):
-            req_obj = getattr(requests, method.lower())
-            r = req_obj(url, data=params, headers=request_headers, verify=verify)
-
-            headers = r.headers
-            if len(r.raw.headers.getlist('Set-Cookie')) > 0:
-                headers['set-cookie'] = r.raw.headers.getlist('Set-Cookie')
-            return headers, r.status_code
+            self.headers = CaseInsensitiveDict(json.loads(headers))
+        else:
+            self.headers = CaseInsensitiveDict(headers)
+        self.reporter = Reporter()
 
     def analyze(self, rules=None):
         """
-        Analyze the currently loaded headers against provided rules.
-
-        :param rules: Override rules to compare headers against
-        :type rules: dict
-        :return: Audit report
-        :rtype: list
+        Analyse the loaded headers against the provided ruleset
+        :param dict rules: The ruleset to validate the headers against
         """
-
-        for header, value in self.headers.items():
-            if type(value) == str:
-                self.headers[header] = value.lower()
-            if type(value) == list:
-                value = [item.lower() for item in value]
-                self.headers[header] = value
-
         if not rules:
             rules = load_rules()
-        for rule, config in rules.items():
-            self.__validate_rules(config, header=rule)
-            if 'Directives' in config and rule in self.headers:
-                for directive, d_config in config['Directives'].items():
-                    self.__validate_rules(d_config, header=rule, directive=directive)
-        return self.report
-
-    def __validate_rule_and_value(self, expected_value, header, directive, Severity=False):
-        """
-        Verify headers content matches provided config.
-
-        :param expected_value: Expected value of header.
-        :param header: Name of header
-        :param directive: Name of directive (optional)
-        :return:
-        """
-        expected_value_list = [str(item).lower() for item in expected_value]
-        if len(expected_value_list) == 1:
-            expected_value_list = [item.strip(' ') for item in expected_value_list[0].split(self.delimiter)]
-
-        if directive:
-            rule = directive
-            headers = _to_dict(self.headers[header], ';', ' ')
-        else:
-            rule = header
-            headers = self.headers
-
-        if rule not in headers:
-            self.__add_report_item(
-                severity=Severity if Severity else "high",
-                error_type=7 if directive else 1,
-                header=header,
-                directive=directive,
-                expected=expected_value_list)
-        else:
-            rule_list = [item.strip(' ') for item in headers[rule].split(self.delimiter)]
-            if not all(elem in expected_value_list for elem in rule_list):
-                self.__add_report_item(
-                    severity=Severity if Severity else "high",
-                    error_type=3,
-                    header=header,
-                    directive=directive,
-                    expected=expected_value_list,
-                    value=headers[rule])
-
-    def __validate_not_exists(self, header, directive, config):
-        """
-        Verify specified rule does not exist in loaded headers.
-
-        :param header: Name of header
-        :param directive: Name of directive (optional)
-        """
-
-        if directive:
-            rule = directive
-            headers = _to_dict(self.headers[header], ';', ' ')
-        else:
-            rule = header
-            headers = self.headers
-
-        if rule in headers:
-            self.__add_report_item(
-                severity=config['Severity'] if ("Severity" in config) else "high",
-                error_type=8 if directive else 2,
-                header=header,
-                directive=directive)
-
-    def __validate_exists(self, header, directive, config):
-        """
-        Verify specified rule exists in loaded headers.
-
-        :param header: Name of header
-        :param directive: Name of directive (optional)
-        """
-        if directive:
-            rule = directive
-            headers = _to_dict(self.headers[header], ';', ' ')
-        else:
-            rule = header
-            headers = self.headers
-
-        if rule not in headers:
-            self.__add_report_item(
-                severity=config['Severity'] if ("Severity" in config) else "high",
-                error_type=7 if directive else 1,
-                header=header,
-                directive=directive)
-
-        return rule in headers  # Return value to prevent subsequent avoid/contain checks if the header is not present
-
-    def __validate_must_avoid(self, config, header, directive):
-        """
-        Verify specified values do not exist in loaded headers.
-
-        :param config: Configuration rule-set to use
-        :param header: Name of header
-        :param directive: Name of directive (optional)
-        """
-        if directive:
-            rule = directive
-            header_value = _to_dict(self.headers[header], ';', ' ')[rule]
-        else:
-            rule = header
-            header_value = self.headers[rule]
-
-        config['Must-Avoid'] = [item.lower() for item in config['Must-Avoid']]
-
-        for avoid_value in config['Must-Avoid']:
-            if avoid_value in header_value and rule not in self.anomalies:
-                if rule.lower() == 'content-security-policy':
-                    policy = _to_dict(self.headers[header], ';', ' ')
-                    non_compliant_values = [item for item in list(policy.values()) if avoid_value in item]
-                    indices = [list(policy.values()).index(item) for item in non_compliant_values]
-                    for index in indices:
-                        self.__add_report_item(
-                            severity=config['Severity'] if ("Severity" in config) else "medium",
-                            error_type=5,
-                            header=header,
-                            directive=list(policy.keys())[index],
-                            avoid=config['Must-Avoid'],
-                            value=avoid_value)
-                else:
-                    self.__add_report_item(
-                        severity=config['Severity'] if ("Severity" in config) else "medium",
-                        error_type=5,
-                        header=header,
-                        directive=directive,
-                        avoid=config['Must-Avoid'],
-                        value=avoid_value)
-
-    def __validate_must_contain(self, config, header, directive):
-        """
-        Verify the provided header contains certain params.
-
-        :param config: Configuration rule-set to use
-        :param header: Name of header
-        :param directive: Name of directive (optional)
-        """
-        if directive:
-            rule = directive
-            header_value = _to_dict(self.headers[header], ';', ' ')[rule]
-        else:
-            rule = header
-            header_value = self.headers[rule]
-
-        if 'Must-Contain-One' in config:
-            config['Must-Contain-One'] = [item.lower() for item in config['Must-Contain-One']]
-            contain_values = header_value.split(' ') if directive else header_value.split(self.delimiter)
-            does_contain = False
-
-            for contain_value in contain_values:
-                contain_value = contain_value.lstrip()
-                if contain_value in config['Must-Contain-One']:
-                    does_contain = True
-                    break
-            if not does_contain:
-                self.__add_report_item(
-                    severity=config['Severity'] if ("Severity" in config) else "high",
-                    error_type=6,
-                    header=header,
-                    directive=directive,
-                    expected=config['Must-Contain-One'],
-                    value=config['Must-Contain-One'])
-
-        elif 'Must-Contain' in config:
-            config['Must-Contain'] = [item.lower() for item in config['Must-Contain']]
-            if header.lower() == 'set-cookie':
+        for header, config in rules.items():
+            if header.lower() != 'set-cookie':
+                self._analyze(config, header)
+            elif header in self.headers:
                 for cookie in self.headers[header]:
-                    for contain_value in config['Must-Contain']:
-                        if contain_value not in cookie:
-                            default_severity = 'high' if contain_value == 'secure' else 'medium'
-                            self.__add_report_item(
-                                severity=config['Severity'] if (contain_value == 'secure' and (
-                                    "Severity" in config)) else default_severity,
-                                error_type=4,
-                                header=header,
-                                expected=config['Must-Contain'],
-                                value=contain_value,
-                                cookie=cookie)
-            else:
-                for contain_value in config['Must-Contain']:
-                    if contain_value not in header_value and rule not in self.anomalies:
-                        self.__add_report_item(
-                            severity=config['Severity'] if ("Severity" in config) else 'medium',
-                            error_type=4,
-                            header=header,
-                            directive=directive,
-                            expected=config['Must-Contain'],
-                            value=contain_value)
+                    self._analyze(config, header, cookie)
+        return self.reporter.report
 
-    def __validate_rules(self, config, header, directive=None):
-        """
-        Entry point for validation.
+    def _analyze(self, config, header, cookie=None):
+        config = CaseInsensitiveDict(config)
+        self._validate_rules(config, header, cookie)
 
-        :param config: Configuration rule-set to use
-        :param header: Name of header
-        :param directive: Name of directive (optional)
-        """
-        try:
-            self.delimiter = config['Delimiter']
-        except KeyError:
-            self.delimiter = ';'
+        if 'directives' in config and header in self.headers:
+            for directive, d_config in config['directives'].items():
+                config = CaseInsensitiveDict(d_config)
+                self._validate_rules(config, header, cookie, directive=directive)
 
-        if config['Required'] is True or (config['Required'] == 'Optional' and header in self.headers):
-            if config['Enforce']:
-                if "Severity" in config:
-                    self.__validate_rule_and_value(config['Value'], header, directive, config['Severity'])
-                else:
-                    self.__validate_rule_and_value(config['Value'], header, directive)
-            else:
-                exists = self.__validate_exists(header, directive, config)
-                if exists:
-                    if 'Must-Contain-One' in config or 'Must-Contain' in config:
-                        self.__validate_must_contain(config, header, directive)
-                    if 'Must-Avoid' in config:
-                        self.__validate_must_avoid(config, header, directive)
-        elif config['Required'] is False:
-            self.__validate_not_exists(header, directive, config)
+    def _validate_rules(self, config, header, cookie, directive=None):
+        is_required = str(config['required']).strip().lower()
 
-    def __add_report_item(self, severity, error_type, header, directive=None, expected=None, avoid=None, value='',
-                          cookie=''):
-        """
-        Add a entry to report.
-
-        :param severity: [low, medium, high]
-        :type severity: str
-        :param error_type: [1...6] related to error_types
-        :type error_type: int
-        :param expected: Expected value of header
-        :param avoid: Avoid value of header
-        :param value: Current value of header
-        :param cookie: Value of cookie (if applicable)
-        """
-        if directive:
-            error = {'rule': header + ' - ' + directive, 'severity': severity, 'message': self.error_types[error_type]}
+        if is_required == 'false':
+            report_item = validate_not_exists(config, self.headers, header, directive)
+            self._add_to_report_if_exists(report_item)
         else:
-            error = {'rule': header, 'severity': severity, 'message': self.error_types[error_type]}
+            exists = self._validate_exists(is_required, config, header, directive)
+            if exists:
+                header_value = cookie if cookie else self.headers[header]
+                self._validate_enforced_value(config, header_value, header, directive)
+                self._validate_avoid_and_contain_values(config, header_value, header, directive)
 
-        if expected:
-            error['expected'] = expected
-            error['delimiter'] = self.delimiter
-        if avoid:
-            error['avoid'] = avoid
-            error['delimiter'] = self.delimiter
+    def _validate_exists(self, is_required, config, header, directive):
+        if is_required == 'true':
+            report_item = validate_exists(config, self.headers, header, directive)
+            self._add_to_report_if_exists(validate_exists(config, self.headers, header, directive))
+            return bool(not report_item)
+        if directive:
+            return directive in parse_policy(self.headers[header], **DELIMITERS[header], keys_only=True)
+        else:
+            return header in self.headers
 
-        if error_type == 3:
-            error['value'] = value
-        elif error_type in (4, 5, 6):
-            if header.lower() == 'set-cookie':
-                error['value'] = cookie
-            else:
-                if directive:
-                    error['value'] = _to_dict(self.headers[header], ';', ' ')[directive].strip('\'')
-                else:
-                    error['value'] = self.headers[header]
-            error['anomaly'] = value
-        self.report.append(error)
+    def _validate_enforced_value(self, config, header_value, header, directive):
+        if config.get('value') is not None:
+            report_item = validate_value(config, header_value, header, directive)
+            self._add_to_report_if_exists(report_item)
+        elif config.get('value-one-of'):
+            report_item = validate_value_one_of(config, header_value, header, directive)
+            self._add_to_report_if_exists(report_item)
+
+    def _validate_avoid_and_contain_values(self, config, header_value, header, directive):
+        if 'must-avoid' in config:
+            report_item = validate_must_avoid(config, header_value, header, directive)
+            self._add_to_report_if_exists(report_item)
+        if 'must-contain' in config:
+            report_item = validate_must_contain(config, header_value, header, directive)
+            self._add_to_report_if_exists(report_item)
+        if 'must-contain-one' in config:
+            report_item = validate_must_contain_one(config, header_value, header, directive)
+            self._add_to_report_if_exists(report_item)
+
+    def _add_to_report_if_exists(self, report_item):
+        if report_item:
+            try:
+                self.reporter.add_item(report_item)
+            except AttributeError:
+                for item in report_item:
+                    self.reporter.add_item(item)
+
+    @staticmethod
+    def _get_headers(url, method, params, headers, verify):
+        if not validators.url(url):
+            raise ValueError(f"Cannot retrieve headers from '{url}'. The URL is malformed")
+
+        request_object = getattr(requests, method.lower())
+        response = request_object(url, data=params, headers=headers, verify=verify)
+        response_headers = response.headers
+
+        if len(response.raw.headers.getlist('Set-Cookie')) > 0:
+            response_headers['set-cookie'] = response.raw.headers.getlist('Set-Cookie')
+        return response_headers

--- a/drheader/core.py
+++ b/drheader/core.py
@@ -7,7 +7,7 @@ from requests.structures import CaseInsensitiveDict
 from drheader.report import Reporter
 from drheader.utils import load_rules, parse_policy
 from drheader.validator import DELIMITERS, validate_exists, validate_not_exists, validate_must_avoid, \
-    validate_must_contain, validate_must_contain_one, validate_value, validate_value_one_of
+    validate_must_contain, validate_must_contain_one, validate_value, validate_value_any_of, validate_value_one_of
 
 
 class Drheader:
@@ -82,10 +82,13 @@ class Drheader:
             return header in self.headers
 
     def _validate_enforced_value(self, config, header_value, header, directive):
-        if config.get('value') is not None:
+        if 'value' in config:
             report_item = validate_value(config, header_value, header, directive)
             self._add_to_report_if_exists(report_item)
-        elif config.get('value-one-of'):
+        if 'value-any-of' in config:
+            report_item = validate_value_any_of(config, header_value, header, directive)
+            self._add_to_report_if_exists(report_item)
+        if 'value-one-of' in config:
             report_item = validate_value_one_of(config, header_value, header, directive)
             self._add_to_report_if_exists(report_item)
 

--- a/drheader/core.py
+++ b/drheader/core.py
@@ -74,7 +74,7 @@ class Drheader:
     def _validate_exists(self, is_required, config, header, directive):
         if is_required == 'true':
             report_item = validate_exists(config, self.headers, header, directive)
-            self._add_to_report_if_exists(validate_exists(config, self.headers, header, directive))
+            self._add_to_report_if_exists(report_item)
             return bool(not report_item)
         if directive:
             return directive in parse_policy(self.headers[header], **DELIMITERS[header], keys_only=True)

--- a/drheader/report.py
+++ b/drheader/report.py
@@ -1,0 +1,60 @@
+from enum import Enum
+
+
+class ErrorType(Enum):
+    DISALLOWED = '{} should not be returned'
+    AVOID = 'Must-Avoid directive included'
+    CONTAIN = 'Must-Contain directive missed'
+    CONTAIN_ONE = 'Must-Contain-One directive missed'
+    REQUIRED = '{} not included in response'
+    VALUE = 'Value does not match security policy'
+
+
+class ReportItem:
+
+    def __init__(self, severity, error_type, header, directive=None, value=None, avoid=None, expected=None,
+                 expected_one=None, anomaly=None, delimiter=None):
+        self.severity = severity
+        self.error_type = error_type
+        self.header = header
+        self.directive = directive
+        self.value = value
+        self.avoid = avoid
+        self.expected = expected
+        self.expected_one = expected_one
+        self.anomaly = anomaly
+        self.delimiter = delimiter
+
+
+class Reporter:
+
+    def __init__(self):
+        self.report = []
+
+    def add_item(self, item):
+        """
+        Add a validation finding to the final report
+        :param item: The report item to add as a validation finding
+        """
+        finding = {
+            'rule': '{} - {}'.format(item.header, item.directive) if item.directive else item.header,
+            'severity': item.severity,
+        }
+        if item.error_type in (ErrorType.DISALLOWED, ErrorType.REQUIRED):
+            finding['message'] = item.error_type.value.format('Directive' if item.directive else 'Header')
+        else:
+            finding['message'] = item.error_type.value
+
+        if item.value:
+            finding['value'] = item.value
+        if item.expected:
+            finding['expected'] = item.expected
+            if len(item.expected) > 1 and item.delimiter:
+                finding['delimiter'] = item.delimiter
+        elif item.expected_one:
+            finding['expected-one'] = item.expected_one
+        if item.avoid:
+            finding['avoid'] = item.avoid
+        if item.anomaly:
+            finding['anomaly'] = item.anomaly
+        self.report.append(finding)

--- a/drheader/report.py
+++ b/drheader/report.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import NamedTuple
 
 
 class ErrorType(Enum):
@@ -12,19 +13,16 @@ class ErrorType(Enum):
     VALUE_ONE = 'Value does not match security policy. Exactly one of the expected items was expected'
 
 
-class ReportItem:
-
-    def __init__(self, severity, error_type, header, directive=None, value=None, avoid=None, expected=None,
-                 anomalies=None, delimiter=None):
-        self.severity = severity
-        self.error_type = error_type
-        self.header = header
-        self.directive = directive
-        self.value = value
-        self.avoid = avoid
-        self.expected = expected
-        self.anomalies = anomalies
-        self.delimiter = delimiter
+class ReportItem(NamedTuple):
+    severity: str
+    error_type: ErrorType
+    header: str
+    directive: str = None
+    value: str = None
+    avoid: list = None
+    expected: list = None
+    anomalies: list = None
+    delimiter: str = None
 
 
 class Reporter:

--- a/drheader/resources/delimiters.json
+++ b/drheader/resources/delimiters.json
@@ -1,0 +1,40 @@
+{
+    "Cache-Control": {
+        "item_delimiter": ",",
+        "key_delimiter": "="
+    },
+    "Clear-Site-Data": {
+        "item_delimiter": ",",
+        "strip_items": "\""
+    },
+    "Content-Security-Policy": {
+        "item_delimiter": ";",
+        "key_delimiter": " ",
+        "value_delimiter": " ",
+        "strip_items": "'"
+    },
+    "Feature-Policy": {
+        "item_delimiter": ";",
+        "key_delimiter": " ",
+        "value_delimiter": " ",
+        "strip_items": "'"
+    },
+    "Referrer-Policy": {
+        "item_delimiter": ","
+    },
+    "Set-Cookie": {
+        "item_delimiter": ";",
+        "key_delimiter": "="
+    },
+    "Strict-Transport-Security": {
+        "item_delimiter": ";",
+        "key_delimiter": "="
+    },
+    "X-Forwarded-For": {
+        "item_delimiter": ","
+    },
+    "X-XSS-Protection": {
+        "item_delimiter": ";",
+        "key_delimiter": "="
+    }
+}

--- a/drheader/resources/delimiters.json
+++ b/drheader/resources/delimiters.json
@@ -5,19 +5,19 @@
     },
     "Clear-Site-Data": {
         "item_delimiter": ",",
-        "strip_items": "\""
+        "strip_items": "\" "
     },
     "Content-Security-Policy": {
         "item_delimiter": ";",
         "key_delimiter": " ",
         "value_delimiter": " ",
-        "strip_items": "'"
+        "strip_items": "' "
     },
     "Feature-Policy": {
         "item_delimiter": ";",
         "key_delimiter": " ",
         "value_delimiter": " ",
-        "strip_items": "'"
+        "strip_items": "' "
     },
     "Referrer-Policy": {
         "item_delimiter": ","

--- a/drheader/rules.yml
+++ b/drheader/rules.yml
@@ -17,11 +17,10 @@ Headers:
                     - self
     Pragma:
         Required: True
-        Value:
-            - no-cache
+        Value: no-cache
     Referrer-Policy:
         Required: True
-        Must-Contain-One:
+        Value-Any-Of:
             - strict-origin
             - strict-origin-when-cross-origin
             - no-referrer
@@ -45,8 +44,7 @@ Headers:
         Required: False
     X-Content-Type-Options:
         Required: True
-        Value:
-            - nosniff
+        Value: nosniff
     X-Forwarded-For:
         Required: False
     X-Frame-Options:
@@ -60,5 +58,4 @@ Headers:
         Required: False
     X-XSS-Protection:
         Required: True
-        Value:
-            - 0
+        Value: 0

--- a/drheader/rules.yml
+++ b/drheader/rules.yml
@@ -1,89 +1,64 @@
 Headers:
+    Cache-Control:
+        Required: True
+        Value:
+            - no-store
+            - max-age=0
     Content-Security-Policy:
         Required: True
-        Enforce: False
-        Value:
-        Must-Contain-One:
-            - default-src 'none'
-            - default-src 'self'
         Must-Avoid:
             - unsafe-inline
             - unsafe-eval
-    X-XSS-Protection:
+        Directives:
+            default-src:
+                Required: True
+                Value-One-Of:
+                    - none
+                    - self
+    Pragma:
         Required: True
-        Enforce: True
         Value:
-            - 0
-    Server:
-        Required: False
-        Enforce: False
-        Value:
-    Strict-Transport-Security:
-        Required: True
-        Enforce: True
-        Value:
-            - max-age=31536000; includeSubDomains
-    X-Frame-Options:
-        Required: True
-        Enforce: True
-        Value:
-            - SAMEORIGIN
-            - DENY
-    X-Content-Type-Options:
-        Required: True
-        Enforce: True
-        Value:
-            - nosniff
-    Set-Cookie:
-        Required: Optional
-        Enforce: False
-        Value:
-        Must-Contain:
-            - HttpOnly
-            - Secure
+            - no-cache
     Referrer-Policy:
         Required: True
-        Enforce: False
-        Delimiter: ','
-        Value:
         Must-Contain-One:
             - strict-origin
             - strict-origin-when-cross-origin
             - no-referrer
-    Cache-Control:
+    Server:
+        Required: False
+    Set-Cookie:
+        Required: Optional
+        Must-Contain:
+            - HttpOnly
+            - Secure
+    Strict-Transport-Security:
         Required: True
-        Enforce: True
-        Delimiter: ','
         Value:
-            - no-store, max-age=0
-    Pragma:
-        Required: True
-        Enforce: True
-        Value:
-            - no-cache
-    X-Powered-By:
-        Required: False
-        Enforce: False
-        Value:
-    X-AspNet-Version:
-        Required: False
-        Enforce: False
-        Value:
-    X-Generator:
-        Required: False
-        Enforce: False
-        Value:
+            - max-age=31536000
+            - includeSubDomains
     User-Agent:
         Required: False
-        Enforce: False
-        Value:
-    X-Forwarded-For:
+    X-AspNet-Version:
         Required: False
-        Enforce: False
-        Value:
     X-Client-IP:
         Required: False
-        Enforce: False
+    X-Content-Type-Options:
+        Required: True
         Value:
-
-    # TODO - Add ruleset and severity
+            - nosniff
+    X-Forwarded-For:
+        Required: False
+    X-Frame-Options:
+        Required: True
+        Value-One-Of:
+            - DENY
+            - SAMEORIGIN
+    X-Generator:
+        Required: False
+    X-Powered-By:
+        Required: False
+    X-XSS-Protection:
+        Required: True
+        Value:
+            - 0

--- a/drheader/utils.py
+++ b/drheader/utils.py
@@ -5,21 +5,52 @@
 import io
 import logging
 import os
+from typing import NamedTuple
 
 import requests
 import yaml
 
 
-def _to_dict(string_to_convert, item_delimiter, key_value_delimiter):
-    result = {}
-    dict_values = list(filter(None, string_to_convert.strip().split(item_delimiter)))
+class KeyValueDirective(NamedTuple):
+    key: str
+    value: list
+    raw_value: str = None
 
-    for item in dict_values:
-        key_value = list(filter(None, item.strip().split(key_value_delimiter, 1)))
-        if len(key_value) == 2:
-            result[key_value[0].strip()] = key_value[1].strip('\'')
 
-    return result
+def parse_policy(policy, item_delimiter, key_delimiter=None, value_delimiter=None, strip_items=None, split_value=True,
+                 keys_only=False, key_values_only=False):
+    """
+    Parse a policy string into a list of individual directives
+    :param str policy: The policy string to be parsed
+    :param str item_delimiter: The character that delimits individual policy items
+    :param str key_delimiter: The character that delimits the kay and value in key-value directives
+    :param str value_delimiter: The character that delimits individual value items in key-value directives
+    :param str strip_items: A string of characters to strip from directive values
+    :param bool split_value: Split the value in a key-value directive into
+    :param bool keys_only: Return only keys and standalone directives
+    :param bool key_values_only: Return only key-value directives
+    """
+    if not item_delimiter:
+        return [policy]
+    if not key_delimiter:
+        return policy.split(item_delimiter)
+
+    policy_items = list(filter(lambda s: s.strip(), policy.strip().split(item_delimiter)))
+    directives = []
+
+    for item in policy_items:
+        directive = list(item.strip(key_delimiter + ' ').split(key_delimiter, 1))
+        key = directive[0].strip()
+        if len(directive) == 1:
+            if not key_values_only:
+                directives.append(key)
+        else:
+            if keys_only:
+                directives.append(key)
+            else:
+                directive = _extract_key_value_directive(directive, value_delimiter, strip_items, split_value)
+                directives.append(directive)
+    return directives
 
 
 def load_rules(rule_file=None, merge=None):
@@ -79,3 +110,12 @@ def get_rules_from_uri(uri):
         raise Exception('No content retrieved from {}'.format(uri))
     file = io.BytesIO(download.content)
     return file
+
+
+def _extract_key_value_directive(directive, value_delimiter, strip_items, split_value):
+    if value_delimiter and split_value:
+        value_items = list(filter(lambda s: s.strip(), directive[1].split(value_delimiter)))
+        value = [item.strip(strip_items) for item in value_items]
+    else:
+        value = [directive[1].strip(strip_items)]
+    return KeyValueDirective(directive[0].strip(), value, directive[1])

--- a/drheader/validator.py
+++ b/drheader/validator.py
@@ -1,0 +1,271 @@
+import json
+import os
+
+from requests.structures import CaseInsensitiveDict
+
+from drheader.report import ReportItem, ErrorType as Error
+from drheader.utils import parse_policy
+
+POLICY_HEADERS = ['content-security-policy', 'feature-policy', 'permissions-policy']
+
+with open(os.path.join(os.path.dirname(__file__), 'resources/delimiters.json')) as delimiters_file:
+    DELIMITERS = CaseInsensitiveDict(json.load(delimiters_file))
+
+
+def validate_exists(config, headers, header, directive=None):
+    """
+    Validate that an expected header or directive is present in the given headers
+    :param config: The configuration of the exists rule
+    :param headers: The headers against which to validate
+    :param header: The header to validate
+    :param directive: The directive to validate
+    """
+    delimiters = _get_delimiters(header, config)
+
+    if directive:
+        exist_item = directive
+        validation_items = parse_policy(headers[header], **delimiters, keys_only=True)
+    else:
+        exist_item = header
+        validation_items = headers.keys()
+
+    validation_items = {str(item).strip().lower() for item in validation_items}
+
+    if exist_item.strip().lower() not in validation_items:
+        severity = config.get('severity', 'high')
+        if 'value' in config:
+            delimiter = delimiters['value_delimiter'] if directive else delimiters['item_delimiter']
+            expected = _get_expected_values(config, 'value', delimiter)
+            return ReportItem(severity, Error.REQUIRED, header, directive, expected=expected, delimiter=delimiter)
+        if 'value-one-of' in config:
+            delimiter = delimiters['value_delimiter'] if directive else delimiters['item_delimiter']
+            expected = _get_expected_values(config, 'value-one-of', delimiter)
+            return ReportItem(severity, Error.REQUIRED, header, directive, expected_one=expected, delimiter=delimiter)
+        else:
+            return ReportItem(severity, Error.REQUIRED, header, directive)
+
+
+def validate_not_exists(config, headers, header, directive=None):
+    """
+    Validate that an expected header or directive is not present in the given headers
+    :param config: The configuration of the not-exists rule
+    :param headers: The headers against which to validate
+    :param header: The header to validate
+    :param directive: The directive to validate
+    """
+    delimiters = _get_delimiters(header, config)
+
+    if directive:
+        not_exist_item = directive
+        validation_items = parse_policy(headers[header], **delimiters, keys_only=True)
+    else:
+        not_exist_item = header
+        validation_items = headers.keys()
+
+    validation_items = {str(item).strip().lower() for item in validation_items}
+
+    if not_exist_item.strip().lower() in validation_items:
+        severity = config.get('severity', 'high')
+        return ReportItem(severity, Error.DISALLOWED, header, directive)
+
+
+def validate_value(config, item_value, header, directive=None):
+    """
+    Validate that a given header or directive matches a given value
+    :param config: The configuration of the enforce-value rule
+    :param item_value: The value of the header or directive against which to validate
+    :param header: The header to validate
+    :param directive: The directive to validate
+    """
+    delimiters = _get_delimiters(header, config)
+
+    if directive:
+        delimiter = delimiters['value_delimiter']
+        kvd = _get_directive(directive, parse_policy(item_value, **delimiters, key_values_only=True))
+        validation_items, raw_value = kvd.value, kvd.raw_value
+    else:
+        delimiter = delimiters['item_delimiter']
+        validation_items = item_value.split(delimiter)
+        raw_value = item_value
+
+    validation_items = {str(item).strip().lower() for item in validation_items}
+    expected = _get_expected_values(config, 'value', delimiter)
+
+    if validation_items != {item.lower() for item in expected}:
+        severity = config.get('severity', 'high')
+        return ReportItem(severity, Error.VALUE, header, directive, raw_value, expected=expected, delimiter=delimiter)
+
+
+def validate_value_one_of(config, item_value, header, directive=None):
+    """
+    Validate that a given header or directive matches a given value
+    :param config: The configuration of the enforce-value rule
+    :param item_value: The value of the header or directive against which to validate
+    :param header: The header to validate
+    :param directive: The directive to validate
+    """
+    delimiters = _get_delimiters(header, config)
+
+    if directive:
+        delimiter = delimiters['value_delimiter']
+        kvd = _get_directive(directive, parse_policy(item_value, **delimiters, split_value=False, key_values_only=True))
+        item_value, raw_value = kvd.value[0], kvd.raw_value
+    else:
+        delimiter = delimiters['item_delimiter']
+        raw_value = item_value
+
+    accepted = _get_expected_values(config, 'value-one-of', delimiter)
+
+    if str(item_value).strip().lower() not in {item.lower() for item in accepted}:
+        severity = config.get('severity', 'high')
+        return ReportItem(severity, Error.VALUE, header, directive, raw_value, expected_one=accepted)
+
+
+def validate_must_avoid(config, item_value, header, directive=None):
+    """
+    Validate that a given header or directive does not contain any of a list of values
+    :param config: The configuration of the must-avoid rule
+    :param item_value: The value of the header or directive against which to validate
+    :param header: The header to validate
+    :param directive: The directive to validate
+    """
+    delimiters = _get_delimiters(header, config)
+
+    if directive:
+        delimiter = delimiters['value_delimiter']
+        kvd = _get_directive(directive, parse_policy(item_value, **delimiters, key_values_only=True))
+        validation_items, raw_value = kvd.value, kvd.raw_value
+    else:
+        if header.strip().lower() in POLICY_HEADERS:
+            return _validate_must_avoid_for_policy_header(config, item_value, header, delimiters)
+        delimiter = delimiters['item_delimiter']
+        validation_items = item_value.split(delimiter) + parse_policy(item_value, **delimiters, keys_only=True)
+        raw_value = item_value
+
+    validation_items = {str(item).strip().lower() for item in validation_items}
+    disallowed = _get_expected_values(config, 'must-avoid', delimiter)
+    severity = config.get('severity', 'medium')
+    findings = []
+
+    for avoid in disallowed:
+        if avoid.lower() in validation_items:
+            item = ReportItem(severity, Error.AVOID, header, directive, raw_value, avoid=disallowed, anomaly=avoid)
+            findings.append(item)
+    return findings
+
+
+def validate_must_contain(config, item_value, header, directive=None):
+    """
+    Validate that a given header or directive contains all of a list of expected values
+    :param config: The configuration of the must-contain-one rule
+    :param item_value: The value of the header or directive against which to validate
+    :param header: The header to validate
+    :param directive: The directive to validate
+    """
+    delimiters = _get_delimiters(header, config)
+
+    if directive:
+        delimiter = delimiters['value_delimiter']
+        kvd = _get_directive(directive, parse_policy(item_value, **delimiters, key_values_only=True))
+        validation_items, raw_value = kvd.value, kvd.raw_value
+    else:
+        delimiter = delimiters['item_delimiter']
+        validation_items = item_value.split(delimiter) + parse_policy(item_value, **delimiters, keys_only=True)
+        raw_value = item_value
+
+    validation_items = {str(item).strip().lower() for item in validation_items}
+    expected = _get_expected_values(config, 'must-contain', delimiter)
+    severity = config.get('severity', 'medium')
+    findings = []
+
+    for contain in expected:
+        if contain.lower() not in validation_items:
+            item = ReportItem(severity, Error.CONTAIN, header, directive, raw_value, expected=expected, anomaly=contain,
+                              delimiter=delimiter)
+            findings.append(item)
+    return findings
+
+
+def validate_must_contain_one(config, item_value, header, directive=None):
+    """
+    Validate that a given header or directive contains at least one of a list of expected values
+    :param config: The configuration of the must-contain-one rule
+    :param item_value: The value of the header or directive against which to validate
+    :param header: The header to validate
+    :param directive: The directive to validate
+    """
+    delimiters = _get_delimiters(header, config)
+
+    if directive:
+        delimiter = delimiters['value_delimiter']
+        kvd = _get_directive(directive, parse_policy(item_value, **delimiters, key_values_only=True))
+        validation_items, raw_value = kvd.value, kvd.raw_value
+    else:
+        delimiter = delimiters['item_delimiter']
+        validation_items = item_value.split(delimiter) + parse_policy(item_value, **delimiters, keys_only=True)
+        raw_value = item_value
+
+    validation_items = {str(item).strip().lower() for item in validation_items}
+    expected = _get_expected_values(config, 'must-contain-one', delimiter)
+
+    if not any(contain.lower() in validation_items for contain in expected):
+        severity = config.get('severity', 'high')
+        return ReportItem(severity, Error.CONTAIN_ONE, header, directive, raw_value, expected_one=expected)
+
+
+def _validate_must_avoid_for_policy_header(config, item_value, header, delimiters):
+    directives_list = parse_policy(item_value, **delimiters)
+    validation_items = item_value.split(delimiters['item_delimiter'])
+
+    for item in directives_list:
+        try:
+            validation_items.append(item.key)
+            validation_items += [value for value in item.value]
+        except AttributeError:
+            validation_items.append(item)
+
+    validation_items = {str(item).strip().lower() for item in validation_items}
+    disallowed = _get_expected_values(config, 'must-avoid', delimiters['item_delimiter'])
+    severity = config.get('severity', 'medium')
+    findings = []
+
+    for avoid in disallowed:
+        if avoid.lower() in validation_items:
+            non_compliant_directives = []
+            for item in directives_list:
+                try:
+                    if avoid in item.value:
+                        non_compliant_directives.append(item)
+                except AttributeError:
+                    pass
+
+            if not non_compliant_directives:
+                item = ReportItem(severity, Error.AVOID, header, value=item_value, avoid=disallowed, anomaly=avoid)
+                findings.append(item)
+            else:
+                for ncd in non_compliant_directives:
+                    directive, value = ncd.key, ncd.raw_value
+                    item = ReportItem(severity, Error.AVOID, header, directive, value, avoid=disallowed, anomaly=avoid)
+                    findings.append(item)
+    return findings
+
+
+def _get_delimiters(header, config):
+    delimiters = DELIMITERS.get(header.strip(), CaseInsensitiveDict())
+
+    delimiters['item_delimiter'] = config.get('item-delimiter', delimiters.get('item_delimiter', None))
+    delimiters['key_delimiter'] = config.get('key-delimiter', delimiters.get('key_delimiter', None))
+    delimiters['value_delimiter'] = config.get('value-delimiter', delimiters.get('value_delimiter', None))
+    delimiters['strip_items'] = delimiters.get('strip_items', None)
+    return delimiters
+
+
+def _get_directive(directive_name, directives_list):
+    return next(item for item in directives_list if item.key.lower() == directive_name.lower())
+
+
+def _get_expected_values(config, key, delimiter):
+    if isinstance(config[key], list):
+        return [str(item).strip() for item in config[key]]
+    else:
+        return [item.strip() for item in str(config[key]).split(delimiter)]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,6 @@ setuptools>=39.0.1
 bandit==1.7.2
 flake8==4.0.1
 safety==1.10.3
-nose>=1.3.6
 validators>=0.14.0
 unittest2==1.1.0
 xmlunittest==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@
 
 """The setup script."""
 
-from setuptools import setup
-
 import os
 import re
+
+from setuptools import setup
 
 base_dir = os.path.dirname(__file__)
 

--- a/tests/integration_tests/test_base.py
+++ b/tests/integration_tests/test_base.py
@@ -1,7 +1,5 @@
 import json
-import logging
 import os
-import re
 
 import unittest2
 import yaml
@@ -11,84 +9,57 @@ from drheader import Drheader
 
 class TestBase(unittest2.TestCase):
 
-    def setUp(self):
-        self.logger = logging.Logger
-
     def tearDown(self):
-        with open(os.path.join(os.path.dirname(__file__), '../../drheader/rules.yml')) as rules_file:
-            default_rules = yaml.safe_load(rules_file.read())
-        with open(os.path.join(os.path.dirname(__file__), '../test_resources/default_rules.yml'), 'w') as rules_file:
-            yaml.dump(default_rules, rules_file, sort_keys=False)
+        self._reset_default_rules()
 
-    def process_test(self, url=None, method="GET", headers=None, status_code=None):
-        with open(os.path.join(os.path.dirname(__file__), '../test_resources/default_rules.yml')) as rules_file:
-            rules = yaml.safe_load(rules_file.read())['Headers']
+    @staticmethod
+    def process_test(headers=None, url=None):
+        with open(os.path.join(os.path.dirname(__file__), '../test_resources/default_rules.yml')) as rules:
+            rules = yaml.safe_load(rules.read())['Headers']
 
-        self.instance = Drheader(url=url, method=method, headers=headers, status_code=status_code)
-        self.instance.analyze(rules=rules)
+        drheader = Drheader(headers=headers, url=url)
+        return drheader.analyze(rules=rules)
 
     @staticmethod
     def get_headers():
-        with open(os.path.join(os.path.dirname(__file__), '../test_resources/headers_ok.json')) as headers_file:
-            return json.loads(headers_file.read())
+        with open(os.path.join(os.path.dirname(__file__), '../test_resources/headers_ok.json')) as headers:
+            return json.load(headers)
 
     @staticmethod
-    def add_or_modify_header(header_name, update_value, headers=None):
-        headers = TestBase.get_headers() if not headers else headers
+    def add_or_modify_header(header_name, update_value):
+        headers = TestBase.get_headers()
         headers[header_name] = update_value
         return headers
 
     @staticmethod
-    def delete_header(header_name, headers=None):
-        headers = TestBase.get_headers() if not headers else headers
+    def delete_header(header_name):
+        headers = TestBase.get_headers()
         if header_name in headers:
             headers.pop(header_name)
         return headers
 
     @staticmethod
-    def modify_directive(header_name, update_value, pattern, headers=None):
-        headers = TestBase.get_headers() if not headers else headers
-        if header_name in headers:
-            search_result = re.search(pattern, headers[header_name])
-            if search_result:
-                headers[header_name] = headers[header_name].replace(search_result.group(), update_value)
-            else:
-                headers[header_name] = headers[header_name] + '; ' + update_value
-        else:
-            headers[header_name] = update_value
-        return headers
-
-    @staticmethod
-    def build_error_message(report, expected_report=None, rule=None, append_text=None):
-        if expected_report is None:
-            expected_report = []
-        elif type(expected_report) is dict:
-            expected_report = expected_report.items()
-
+    def build_error_message(report, expected=None, rule=None):
         unexpected_items = []
         for item in report:
-            if rule and item['rule'] == rule and item not in expected_report:
-                unexpected_items.append(item)
-            elif not rule and item not in expected_report:
-                unexpected_items.append(item)
+            if item != expected:
+                if rule and item['rule'].startswith(rule):
+                    unexpected_items.append(item)
+                elif not rule:
+                    unexpected_items.append(item)
 
-        missing_items = []
-        for item in expected_report:
-            if item not in report:
-                missing_items.append(item)
-
-        error_message = "\n"
+        error_message = '\n'
         if len(unexpected_items) > 0:
-            error_message += "\nThe following items were found but were not expected in the report: \n"
+            error_message += '\nThe following items were found but were not expected in the report:\n'
             error_message += json.dumps(unexpected_items, indent=2)
-        if len(missing_items) > 0:
-            error_message += "\nThe following items were not found but were expected in the report: \n"
-            error_message += json.dumps(missing_items, indent=2)
-        if append_text:
-            error_message = '%s\n\n%s' % (error_message, append_text)
+        if expected and expected not in report:
+            error_message += '\n\nThe following was not found but was expected in the report:\n'
+            error_message += json.dumps(expected, indent=2)
         return error_message
 
-
-# start unittest2 to run these tests
-if __name__ == "__main__":
-    unittest2.main()
+    @staticmethod
+    def _reset_default_rules():
+        with open(os.path.join(os.path.dirname(__file__), '../../drheader/rules.yml')) as rules, \
+             open(os.path.join(os.path.dirname(__file__), '../test_resources/default_rules.yml'), 'w') as default_rules:
+            rules = yaml.safe_load(rules.read())
+            yaml.dump(rules, default_rules, indent=2, sort_keys=False)

--- a/tests/integration_tests/test_drheader.py
+++ b/tests/integration_tests/test_drheader.py
@@ -8,293 +8,217 @@ from tests.integration_tests.test_base import TestBase
 class TestDrHeader(TestBase):
 
     def test_get_headers_from_url_ok(self):
-        self.process_test(url='https://google.com')
-        self.assertNotEqual(self.instance.report, None)
+        report = super().process_test(url='https://google.com')
+        self.assertIsNotNone(report)
 
     def test_headers_case_insensitive_keys_ok(self):
-        rule_value = {'Required': True, 'Enforce': False}
-        self.modify_rule('Content-Security-Policy', rule_value)
-
-        headers = self.add_or_modify_header('Content-Security-Policy', "default-src 'none'")
+        self.modify_rule('Content-Security-Policy', {'Required': True})
+        headers = super().add_or_modify_header('Content-Security-Policy', "default-src 'none'")
         headers['CONTENT-SECURITY-POLICY'] = headers.pop('Content-Security-Policy')
-        unexpected_item_regex = ".*" \
-            "'rule': 'Content-Security-Policy', " \
-            "(.*, )?" \
-            "'message': 'Header not included in response'" \
-            ".*"
 
-        self.process_test(headers=headers, status_code=200)
-        self.assertNotRegex(str(self.instance.report), unexpected_item_regex,
-                            msg=self.build_error_message(self.instance.report, rule='Content-Security-Policy', append_text='Regex matched'))
+        report = super().process_test(headers=headers)
+        self.assertEqual(0, len(report), msg=super().build_error_message(report))
 
     def test_headers_case_insensitive_values_ok(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Must-Contain': ["default-src 'none'"]}
-        self.modify_rule('Content-Security-Policy', rule_value)
-
-        headers = self.add_or_modify_header('Content-Security-Policy', "default-src 'none'")
+        self.modify_rule('Content-Security-Policy', {'Required': True, 'Must-Contain': ['default-src']})
+        headers = super().add_or_modify_header('Content-Security-Policy', "default-src 'none'")
         headers['Content-Security-Policy'] = headers.pop('Content-Security-Policy').upper()
-        unexpected_item_regex = ".*" \
-            "'rule': 'Content-Security-Policy', " \
-            "(.*, )?" \
-            "'message': 'Must-Contain directive missed'" \
-            ".*"
 
-        self.process_test(headers=headers, status_code=200)
-        self.assertNotRegex(str(self.instance.report), unexpected_item_regex,
-                            msg=self.build_error_message(self.instance.report, rule='Content-Security-Policy', append_text='Regex matched'))
+        report = super().process_test(headers=headers)
+        self.assertEqual(0, len(report), msg=super().build_error_message(report))
 
     def test_optional_header_not_present_ok(self):
-        rule_value = {'Required': 'Optional', 'Enforce': True, 'Value': ['0']}
-        self.modify_rule('X-XSS-Protection', rule_value)
+        self.modify_rule('X-XSS-Protection', {'Required': 'Optional', 'Value': ['0']})
+        headers = super().delete_header('X-XSS-Protection')
 
-        headers = self.delete_header('X-XSS-Protection')
-        unexpected_item_regex = ".*" \
-            "'rule': 'X-XSS-Protection', " \
-            "(.*, )?" \
-            "'message': 'Header not included in response'" \
-            ".*"
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertNotRegex(str(self.instance.report), unexpected_item_regex,
-                            msg=self.build_error_message(self.instance.report, rule='X-XSS-Protection', append_text='Regex matched'))
+        report = super().process_test(headers=headers)
+        self.assertEqual(0, len(report), msg=super().build_error_message(report))
 
     def test_optional_header_ko(self):
-        rule_value = {'Required': 'Optional', 'Enforce': True, 'Value': ['0']}
-        self.modify_rule('X-XSS-Protection', rule_value)
+        self.modify_rule('X-XSS-Protection', {'Required': 'Optional', 'Value': 0})
+        headers = super().add_or_modify_header('X-XSS-Protection', '1; mode=block')
 
-        headers = self.add_or_modify_header('X-XSS-Protection', '1; mode=block')
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'X-XSS-Protection',
             'severity': 'high',
             'message': 'Value does not match security policy',
             'expected': ['0'],
-            'delimiter': ';',
             'value': '1; mode=block'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-XSS-Protection'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-XSS-Protection'))
 
     def test_header_required_ko(self):
-        rule_value = {'Required': True, 'Enforce': False}
-        self.modify_rule('Strict-Transport-Security', rule_value)
+        self.modify_rule('Strict-Transport-Security', {'Required': True})
+        headers = super().delete_header('Strict-Transport-Security')
 
-        headers = self.delete_header('Strict-Transport-Security')
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Strict-Transport-Security',
             'severity': 'high',
             'message': 'Header not included in response'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Strict-Transport-Security'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Strict-Transport-Security'))
 
     def test_header_disallowed_ko(self):
-        rule_value = {'Required': False}
-        self.modify_rule('Server', rule_value)
+        self.modify_rule('Server', {'Required': False})
+        headers = super().add_or_modify_header('Server', 'Apache/2.4.1 (Unix)')
 
-        headers = self.add_or_modify_header('Server', 'Apache/2.4.1 (Unix)')
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'severity': 'high',
             'rule': 'Server',
             'message': 'Header should not be returned'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Server'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Server'))
 
     def test_header_enforced_value_ko(self):
-        rule_value = {'Required': True, 'Enforce': True, 'Value': ['DENY']}
-        self.modify_rule('X-Frame-Options', rule_value)
+        self.modify_rule('X-Frame-Options', {'Required': True, 'Value': ['DENY']})
+        headers = super().add_or_modify_header('X-Frame-Options', 'SAMEORIGIN')
 
-        headers = self.add_or_modify_header('X-Frame-Options', 'SAMEORIGIN')
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'X-Frame-Options',
             'severity': 'high',
             'message': 'Value does not match security policy',
-            'expected': ['deny'],
-            'delimiter': ';',
-            'value': 'sameorigin'
+            'expected': ['DENY'],
+            'value': 'SAMEORIGIN'
         }
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Frame-Options'))
 
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-Frame-Options'))
+    def test_header_enforced_value_one_of_ko(self):
+        self.modify_rule('Referrer-Policy', {'Required': True, 'Value-One-Of': ['same-origin', 'no-referrer']})
+        headers = super().add_or_modify_header('Referrer-Policy', 'origin-when-cross-origin')
+
+        report = super().process_test(headers=headers)
+        expected = {
+            'rule': 'Referrer-Policy',
+            'severity': 'high',
+            'message': 'Value does not match security policy',
+            'value': 'origin-when-cross-origin',
+            'expected-one': ['same-origin', 'no-referrer']
+        }
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Referrer-Policy'))
 
     def test_header_must_contain_ko(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Must-Contain': ['Secure', 'HttpOnly']}
-        self.modify_rule('Set-Cookie', rule_value)
+        self.modify_rule('Set-Cookie', {'Required': True, 'Must-Contain': ['Secure', 'HttpOnly']})
+        headers = super().add_or_modify_header('Set-Cookie', ['session_id=647388212; HttpOnly; SameSite=Strict'])
 
-        headers = self.add_or_modify_header('Set-Cookie', ['session_id=647388212; HttpOnly; SameSite=Strict'])
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Set-Cookie',
-            'severity': 'high',
+            'severity': 'medium',
             'message': 'Must-Contain directive missed',
-            'expected': ['secure', 'httponly'],
-            'delimiter': ';',
-            'value': 'session_id=647388212; httponly; samesite=strict',
-            'anomaly': 'secure'
+            'expected': ['Secure', 'HttpOnly'],
+            'value': 'session_id=647388212; HttpOnly; SameSite=Strict',
+            'anomaly': 'Secure',
+            'delimiter': ';'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Set-Cookie'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Set-Cookie'))
 
     def test_header_must_contain_one_ko(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Must-Contain-One': ['must-revalidate', 'no-cache']}
-        self.modify_rule('Cache-Control', rule_value)
+        self.modify_rule('Cache-Control', {'Required': True, 'Must-Contain-One': ['must-revalidate', 'no-cache']})
+        headers = super().add_or_modify_header('Cache-Control', 'public')
 
-        headers = self.add_or_modify_header('Cache-Control', 'public')
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Cache-Control',
             'severity': 'high',
             'message': 'Must-Contain-One directive missed',
-            'expected': ['must-revalidate', 'no-cache'],
-            'delimiter': ';',
-            'value': 'public',
-            'anomaly': ['must-revalidate', 'no-cache']
+            'expected-one': ['must-revalidate', 'no-cache'],
+            'value': 'public'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Cache-Control'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Cache-Control'))
 
     def test_header_must_avoid_ko(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Must-Avoid': ['unsafe-inline', 'unsafe-eval']}
-        self.modify_rule('Content-Security-Policy', rule_value)
+        self.modify_rule('Content-Security-Policy', {'Required': True, 'Must-Avoid': ['unsafe-inline', 'unsafe-eval']})
+        headers = super().add_or_modify_header('Content-Security-Policy', "default-src 'self'; style-src 'unsafe-eval'")
 
-        headers = self.add_or_modify_header('Content-Security-Policy', "default-src 'self'; connect-src 'unsafe-inline'")
-        expected_report_item = {
-            'rule': 'Content-Security-Policy - connect-src',
+        report = super().process_test(headers=headers)
+        expected = {
+            'rule': 'Content-Security-Policy - style-src',
             'severity': 'medium',
             'message': 'Must-Avoid directive included',
             'avoid': ['unsafe-inline', 'unsafe-eval'],
-            'delimiter': ';',
-            'value': 'unsafe-inline',
-            'anomaly': 'unsafe-inline'
+            'value': "'unsafe-eval'",
+            'anomaly': 'unsafe-eval'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Content-Security-Policy'))
-
-    def test_directive_required_ko(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Directives': {'default-src': {'Required': True, 'Enforce': False}}}
-        self.modify_rule('Content-Security-Policy', rule_value)
-
-        headers = self.modify_directive('Content-Security-Policy', '', pattern='default-src [^;]*(;)?')
-        expected_report_item = {
-            'rule': 'Content-Security-Policy - default-src',
-            'severity': 'high',
-            'message': 'Directive not included in response'
-        }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Content-Security-Policy - default-src'))
-
-    def test_directive_disallowed_ko(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Directives': {'referrer': {'Required': False}}}
-        self.modify_rule('Content-Security-Policy', rule_value)
-
-        headers = self.modify_directive('Content-Security-Policy', 'referrer no-referrer;', pattern='referrer [^;]*(;)?')
-        expected_report_item = {
-            'rule': 'Content-Security-Policy - referrer',
-            'severity': 'high',
-            'message': 'Directive should not be returned'
-        }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Content-Security-Policy - referrer'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Content-Security-Policy'))
 
     def test_directive_enforced_value_ko(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Directives': {'script-src': {'Required': True, 'Enforce': True, 'Delimiter': ' ', 'Value': ['self']}}}
-        self.modify_rule('Content-Security-Policy', rule_value)
+        self.modify_rule('Content-Security-Policy', {'Required': True, 'Directives': {'script-src': {'Required': True, 'Value': ['self']}}})
+        headers = super().add_or_modify_header('Content-Security-Policy', 'script-src https://example.com')
 
-        headers = self.modify_directive('Content-Security-Policy', 'script-src https://www.santander.co.uk;', pattern='script-src [^;]*(;)?')
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Content-Security-Policy - script-src',
             'severity': 'high',
             'message': 'Value does not match security policy',
             'expected': ['self'],
-            'delimiter': ' ',
-            'value': 'https://www.santander.co.uk'
+            'value': 'https://example.com'
         }
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Content-Security-Policy'))
 
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Content-Security-Policy - script-src'))
+    def test_directive_enforced_value_one_of_ko(self):
+        self.modify_rule('Content-Security-Policy', {'Required': True, 'Directives': {'default-src': {'Required': True, 'Value-One-Of': ['none', 'self']}}})
+        headers = super().add_or_modify_header('Content-Security-Policy', 'default-src https://example.com')
+
+        report = super().process_test(headers=headers)
+        expected = {
+            'rule': 'Content-Security-Policy - default-src',
+            'severity': 'high',
+            'message': 'Value does not match security policy',
+            'value': 'https://example.com',
+            'expected-one': ['none', 'self']
+        }
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Content-Security-Policy'))
 
     def test_directive_must_contain_ko(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Directives': {'connect-src': {'Required': True, 'Enforce': False, 'Delimiter': ' ', 'Must-Contain': ['https://www.santander.co.uk']}}}
-        self.modify_rule('Content-Security-Policy', rule_value)
+        self.modify_rule('Content-Security-Policy', {'Required': True, 'Directives': {'connect-src': {'Required': True, 'Must-Contain': ['https://example.com']}}})
+        headers = super().add_or_modify_header('Content-Security-Policy', "default-src 'none'; connect-src 'self'")
 
-        headers = self.modify_directive('Content-Security-Policy', "connect-src 'self';", pattern='connect-src [^;]*(;)?')
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Content-Security-Policy - connect-src',
             'severity': 'medium',
             'message': 'Must-Contain directive missed',
-            'expected': ['https://www.santander.co.uk'],
-            'delimiter': ' ',
-            'value': 'self',
-            'anomaly': 'https://www.santander.co.uk'
+            'expected': ['https://example.com'],
+            'value': "'self'",
+            'anomaly': 'https://example.com'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Content-Security-Policy - connect-src'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Content-Security-Policy'))
 
     def test_directive_must_contain_one_ko(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Directives': {'base-uri': {'Required': True, 'Enforce': False, 'Delimiter': ' ', 'Must-Contain-One': ['https://www.santander.co.uk', 'https://www.santander.com']}}}
-        self.modify_rule('Content-Security-Policy', rule_value)
+        self.modify_rule('Content-Security-Policy', {'Required': True, 'Directives': {'base-uri': {'Required': True, 'Must-Contain-One': ['https://example1.com', 'https://example2.com']}}})
+        headers = super().add_or_modify_header('Content-Security-Policy', "default-src 'none'; base-uri 'self'")
 
-        headers = self.modify_directive('Content-Security-Policy', "base-uri 'self';", pattern='base-uri [^;]*(;)?')
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Content-Security-Policy - base-uri',
             'severity': 'high',
             'message': 'Must-Contain-One directive missed',
-            'expected': ['https://www.santander.co.uk', 'https://www.santander.com'],
-            'delimiter': ' ',
-            'value': 'self',
-            'anomaly': ['https://www.santander.co.uk', 'https://www.santander.com']
+            'expected-one': ['https://example1.com', 'https://example2.com'],
+            'value': "'self'"
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Content-Security-Policy - base-uri'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Content-Security-Policy'))
 
     def test_directive_must_avoid_ko(self):
-        rule_value = {'Required': True, 'Enforce': False, 'Directives': {'sandbox': {'Required': True, 'Enforce': False, 'Delimiter': ' ', 'Must-Avoid': ['allow-downloads']}}}
-        self.modify_rule('Content-Security-Policy', rule_value)
+        self.modify_rule('Content-Security-Policy', {'Required': True, 'Directives': {'sandbox': {'Required': True, 'Must-Avoid': ['allow-scripts']}}})
+        headers = super().add_or_modify_header('Content-Security-Policy', 'sandbox allow-scripts allow-modals')
 
-        headers = self.modify_directive('Content-Security-Policy', 'sandbox allow-downloads allow-modals;', pattern='sandbox [^;]*(;)?')
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Content-Security-Policy - sandbox',
             'severity': 'medium',
             'message': 'Must-Avoid directive included',
-            'avoid': ['allow-downloads'],
-            'delimiter': ' ',
-            'value': 'allow-downloads allow-modals',
-            'anomaly': 'allow-downloads'
+            'avoid': ['allow-scripts'],
+            'value': 'allow-scripts allow-modals',
+            'anomaly': 'allow-scripts'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Content-Security-Policy - sandbox'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Content-Security-Policy'))
 
     @staticmethod
-    def modify_rule(rule_name, update_value, modify_key=None):
-        with open(os.path.join(os.path.dirname(__file__), '../test_resources/default_rules.yml')) as rules_file:
-            rules = yaml.safe_load(rules_file.read())
-        if modify_key:
-            rules['Headers'][rule_name][modify_key] = update_value
-        elif update_value is None:
-            rules['Headers'].pop(rule_name)
-        else:
-            rules['Headers'][rule_name] = update_value
-        with open(os.path.join(os.path.dirname(__file__), '../test_resources/default_rules.yml'), 'w') as rules_file:
-            yaml.dump(rules, rules_file, sort_keys=False)
+    def modify_rule(rule_name, rule_value):
+        with open(os.path.join(os.path.dirname(__file__), '../test_resources/default_rules.yml'), 'w') as rules:
+            modified_rule = {'Headers': {rule_name: rule_value}}
+            yaml.dump(modified_rule, rules, sort_keys=False)

--- a/tests/integration_tests/test_rules.py
+++ b/tests/integration_tests/test_rules.py
@@ -29,7 +29,7 @@ class TestDefaultRules(TestBase):
         expected = {
             'rule': 'Cache-Control',
             'severity': 'high',
-            'message': 'Value does not match security policy',
+            'message': 'Value does not match security policy. All of the expected items were expected',
             'expected': ['no-store', 'max-age=0'],
             'delimiter': ',',
             'value': 'no-cache'
@@ -54,8 +54,8 @@ class TestDefaultRules(TestBase):
         expected = {
             'rule': 'Content-Security-Policy - default-src',
             'severity': 'high',
-            'message': 'Value does not match security policy',
-            'expected-one': ['none', 'self'],
+            'message': 'Value does not match security policy. Exactly one of the expected items was expected',
+            'expected': ['none', 'self'],
             'value': 'https://example.com'
         }
         self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Content-Security-Policy'))
@@ -79,7 +79,9 @@ class TestDefaultRules(TestBase):
         expected = {
             'rule': 'Referrer-Policy',
             'severity': 'high',
-            'message': 'Header not included in response'
+            'message': 'Header not included in response',
+            'expected': ['strict-origin', 'strict-origin-when-cross-origin', 'no-referrer'],
+            'delimiter': ','
         }
         self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Referrer-Policy'))
 
@@ -90,9 +92,11 @@ class TestDefaultRules(TestBase):
         expected = {
             'rule': 'Referrer-Policy',
             'severity': 'high',
-            'message': 'Must-Contain-One directive missed',
-            'expected-one': ['strict-origin', 'strict-origin-when-cross-origin', 'no-referrer'],
-            'value': 'same-origin'
+            'message': 'Value does not match security policy. At least one of the expected items was expected',
+            'expected': ['strict-origin', 'strict-origin-when-cross-origin', 'no-referrer'],
+            'value': 'same-origin',
+            'anomalies': ['same-origin'],
+            'delimiter': ','
         }
         self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Referrer-Policy'))
 
@@ -114,10 +118,10 @@ class TestDefaultRules(TestBase):
         expected = {
             'rule': 'Set-Cookie',
             'severity': 'medium',
-            'message': 'Must-Contain directive missed',
+            'message': 'Must-Contain directive missed. All of the expected items were expected',
             'expected': ['HttpOnly', 'Secure'],
             'value': 'session_id=585733723; HttpOnly; SameSite=Strict',
-            'anomaly': 'Secure',
+            'anomalies': ['Secure'],
             'delimiter': ';'
         }
         self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Set-Cookie'))
@@ -129,10 +133,10 @@ class TestDefaultRules(TestBase):
         expected = {
             'rule': 'Set-Cookie',
             'severity': 'medium',
-            'message': 'Must-Contain directive missed',
+            'message': 'Must-Contain directive missed. All of the expected items were expected',
             'expected': ['HttpOnly', 'Secure'],
             'value': 'session_id=585733723; Secure; SameSite=Strict',
-            'anomaly': 'HttpOnly',
+            'anomalies': ['HttpOnly'],
             'delimiter': ';',
         }
         self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Set-Cookie'))
@@ -203,7 +207,7 @@ class TestDefaultRules(TestBase):
             'rule': 'X-Frame-Options',
             'severity': 'high',
             'message': 'Header not included in response',
-            'expected-one': ['DENY', 'SAMEORIGIN']
+            'expected': ['DENY', 'SAMEORIGIN']
         }
         self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Frame-Options'))
 
@@ -214,8 +218,8 @@ class TestDefaultRules(TestBase):
         expected = {
             'rule': 'X-Frame-Options',
             'severity': 'high',
-            'message': 'Value does not match security policy',
-            'expected-one': ['DENY', 'SAMEORIGIN'],
+            'message': 'Value does not match security policy. Exactly one of the expected items was expected',
+            'expected': ['DENY', 'SAMEORIGIN'],
             'value': 'ALLOW-FROM https//example.com'
         }
         self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Frame-Options'))
@@ -272,7 +276,7 @@ class TestDefaultRules(TestBase):
         expected = {
             'rule': 'X-XSS-Protection',
             'severity': 'high',
-            'message': 'Value does not match security policy',
+            'message': 'Value does not match security policy. All of the expected items were expected',
             'expected': ['0'],
             'value': '1; mode=block'
         }

--- a/tests/integration_tests/test_rules.py
+++ b/tests/integration_tests/test_rules.py
@@ -4,28 +4,29 @@ from tests.integration_tests.test_base import TestBase
 class TestDefaultRules(TestBase):
 
     def test_compare_rules_ok(self):
-        headers = TestBase.get_headers()
+        headers = super().get_headers()
 
-        self.process_test(headers=headers, status_code=200)
-        self.assertEqual(len(self.instance.report), 0, msg=self.build_error_message(self.instance.report))
+        report = super().process_test(headers=headers)
+        self.assertEqual(len(report), 0, msg=super().build_error_message(report))
 
     def test_cache_control_not_present_ko(self):
-        headers = self.delete_header('Cache-Control')
-        expected_report_item = {
+        headers = super().delete_header('Cache-Control')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Cache-Control',
             'severity': 'high',
             'message': 'Header not included in response',
             'expected': ['no-store', 'max-age=0'],
             'delimiter': ','
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Cache-Control'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Cache-Control'))
 
     def test_cache_control_allow_caching_ko(self):
-        headers = self.add_or_modify_header('Cache-Control', 'no-cache')
-        expected_report_item = {
+        headers = super().add_or_modify_header('Cache-Control', 'no-cache')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Cache-Control',
             'severity': 'high',
             'message': 'Value does not match security policy',
@@ -33,279 +34,246 @@ class TestDefaultRules(TestBase):
             'delimiter': ',',
             'value': 'no-cache'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Cache-Control'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Cache-Control'))
 
     def test_csp_not_present_ko(self):
-        headers = self.delete_header('Content-Security-Policy')
-        expected_report_item = {
+        headers = super().delete_header('Content-Security-Policy')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Content-Security-Policy',
             'severity': 'high',
             'message': 'Header not included in response'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Content-Security-Policy'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Content-Security-Policy'))
 
     def test_csp_default_src_ko(self):
-        headers = self.add_or_modify_header('Content-Security-Policy', "default-src 'https://www.santander.co.uk'")
-        expected_report_item = {
-            'rule': 'Content-Security-Policy',
-            'severity': 'high',
-            'message': 'Must-Contain-One directive missed',
-            'expected': ["default-src 'none'", "default-src 'self'"],
-            'delimiter': ';',
-            'value': "default-src 'https://www.santander.co.uk'",
-            'anomaly': ["default-src 'none'", "default-src 'self'"]
-        }
+        headers = super().add_or_modify_header('Content-Security-Policy', 'default-src https://example.com')
 
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Content-Security-Policy'))
+        report = super().process_test(headers=headers)
+        expected = {
+            'rule': 'Content-Security-Policy - default-src',
+            'severity': 'high',
+            'message': 'Value does not match security policy',
+            'expected-one': ['none', 'self'],
+            'value': 'https://example.com'
+        }
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Content-Security-Policy'))
 
     def test_pragma_not_present_ko(self):
-        headers = self.delete_header('Pragma')
-        expected_report_item = {
+        headers = super().delete_header('Pragma')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Pragma',
             'severity': 'high',
             'message': 'Header not included in response',
-            'expected': ['no-cache'],
-            'delimiter': ';'
+            'expected': ['no-cache']
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Pragma'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Pragma'))
 
     def test_referrer_policy_not_present_ko(self):
-        headers = self.delete_header('Referrer-Policy')
-        expected_report_item = {
+        headers = super().delete_header('Referrer-Policy')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Referrer-Policy',
             'severity': 'high',
             'message': 'Header not included in response'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Referrer-Policy'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Referrer-Policy'))
 
     def test_referrer_policy_not_strict_ko(self):
-        headers = self.add_or_modify_header('Referrer-Policy', 'same-origin')
-        expected_report_item = {
+        headers = super().add_or_modify_header('Referrer-Policy', 'same-origin')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Referrer-Policy',
             'severity': 'high',
             'message': 'Must-Contain-One directive missed',
-            'expected': ['strict-origin', 'strict-origin-when-cross-origin', 'no-referrer'],
-            'delimiter': ',',
-            'value': 'same-origin',
-            'anomaly': ['strict-origin', 'strict-origin-when-cross-origin', 'no-referrer']
+            'expected-one': ['strict-origin', 'strict-origin-when-cross-origin', 'no-referrer'],
+            'value': 'same-origin'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Referrer-Policy'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Referrer-Policy'))
 
     def test_server_ko(self):
-        headers = self.add_or_modify_header('Server', 'Apache/2.4.1 (Unix)')
-        expected_report_item = {
+        headers = super().add_or_modify_header('Server', 'Apache/2.4.1 (Unix)')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'severity': 'high',
             'rule': 'Server',
             'message': 'Header should not be returned'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Server'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Server'))
 
     def test_set_cookie_not_secure_ko(self):
-        headers = self.add_or_modify_header('Set-Cookie', ['session_id=585733723; HttpOnly; SameSite=Strict'])
-        expected_report_item = {
-            'rule': 'Set-Cookie',
-            'severity': 'high',
-            'message': 'Must-Contain directive missed',
-            'expected': ['httponly', 'secure'],
-            'delimiter': ';',
-            'value': 'session_id=585733723; httponly; samesite=strict',
-            'anomaly': 'secure'
-        }
+        headers = super().add_or_modify_header('Set-Cookie', ['session_id=585733723; HttpOnly; SameSite=Strict'])
 
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Set-Cookie'))
-
-    def test_set_cookie_not_httponly_ko(self):
-        headers = self.add_or_modify_header('Set-Cookie', ['session_id=585733723; Secure; SameSite=Strict'])
-        expected_report_item = {
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Set-Cookie',
             'severity': 'medium',
             'message': 'Must-Contain directive missed',
-            'expected': ['httponly', 'secure'],
-            'delimiter': ';',
-            'value': 'session_id=585733723; secure; samesite=strict',
-            'anomaly': 'httponly'
+            'expected': ['HttpOnly', 'Secure'],
+            'value': 'session_id=585733723; HttpOnly; SameSite=Strict',
+            'anomaly': 'Secure',
+            'delimiter': ';'
         }
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Set-Cookie'))
 
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Set-Cookie'))
+    def test_set_cookie_not_httponly_ko(self):
+        headers = super().add_or_modify_header('Set-Cookie', ['session_id=585733723; Secure; SameSite=Strict'])
+
+        report = super().process_test(headers=headers)
+        expected = {
+            'rule': 'Set-Cookie',
+            'severity': 'medium',
+            'message': 'Must-Contain directive missed',
+            'expected': ['HttpOnly', 'Secure'],
+            'value': 'session_id=585733723; Secure; SameSite=Strict',
+            'anomaly': 'HttpOnly',
+            'delimiter': ';',
+        }
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Set-Cookie'))
 
     def test_strict_transport_security_not_present_ko(self):
-        headers = self.delete_header('Strict-Transport-Security')
-        expected_report_item = {
+        headers = super().delete_header('Strict-Transport-Security')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'Strict-Transport-Security',
             'severity': 'high',
             'message': 'Header not included in response',
-            'expected': ['max-age=31536000', 'includesubdomains'],
+            'expected': ['max-age=31536000', 'includeSubDomains'],
             'delimiter': ';'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='Strict-Transport-Security'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Strict-Transport-Security'))
 
     def test_user_agent_ko(self):
-        headers = self.add_or_modify_header('User-Agent', 'Dalvik/2.1.0 (Linux; U; Android 6.0.1; Nexus Player Build/MMB29T)')
-        expected_report_item = {
+        headers = super().add_or_modify_header('User-Agent', 'Dalvik/2.1.0 (Linux; U; Android 6.0.1; Nexus Player)')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'severity': 'high',
             'rule': 'User-Agent',
             'message': 'Header should not be returned'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='User-Agent'))
+        self.assertIn(expected, report, msg=self.build_error_message(report, expected, 'User-Agent'))
 
     def test_x_aspnet_version_ko(self):
-        headers = self.add_or_modify_header('X-AspNet-Version', '2.0.50727')
-        expected_report_item = {
+        headers = super().add_or_modify_header('X-AspNet-Version', '2.0.50727')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'severity': 'high',
             'rule': 'X-AspNet-Version',
             'message': 'Header should not be returned'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-AspNet-Version'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-AspNet-Version'))
 
     def test_x_client_ip_ko(self):
-        headers = self.add_or_modify_header('X-Client-IP', '27.59.32.182')
-        expected_report_item = {
+        headers = super().add_or_modify_header('X-Client-IP', '27.59.32.182')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'severity': 'high',
             'rule': 'X-Client-IP',
             'message': 'Header should not be returned'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-Client-IP'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Client-IP'))
 
     def test_x_content_type_options_not_present_ko(self):
-        headers = self.delete_header('X-Content-Type-Options')
-        expected_report_item = {
+        headers = super().delete_header('X-Content-Type-Options')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'X-Content-Type-Options',
             'severity': 'high',
             'message': 'Header not included in response',
-            'expected': ['nosniff'],
-            'delimiter': ';'
+            'expected': ['nosniff']
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-Content-Type-Options'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Content-Type-Options'))
 
     def test_x_frame_options_not_present_ko(self):
-        headers = self.delete_header('X-Frame-Options')
-        expected_report_item = {
+        headers = super().delete_header('X-Frame-Options')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'X-Frame-Options',
             'severity': 'high',
             'message': 'Header not included in response',
-            'expected': ['sameorigin', 'deny'],
-            'delimiter': ';'
+            'expected-one': ['DENY', 'SAMEORIGIN']
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-Frame-Options'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Frame-Options'))
 
     def test_x_frame_options_allow_from_ko(self):
-        headers = self.add_or_modify_header('X-Frame-Options', 'ALLOW-FROM https//www.unsafe-url.com')
-        expected_report_item = {
+        headers = super().add_or_modify_header('X-Frame-Options', 'ALLOW-FROM https//example.com')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'X-Frame-Options',
             'severity': 'high',
             'message': 'Value does not match security policy',
-            'expected': ['sameorigin', 'deny'],
-            'delimiter': ';',
-            'value': 'allow-from https//www.unsafe-url.com'
+            'expected-one': ['DENY', 'SAMEORIGIN'],
+            'value': 'ALLOW-FROM https//example.com'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-Frame-Options'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Frame-Options'))
 
     def test_x_forwarded_for_ko(self):
-        headers = self.add_or_modify_header('X-Forwarded-For', '2001:db8:85a3:8d3:1319:8a2e:370:7348')
-        expected_report_item = {
+        headers = super().add_or_modify_header('X-Forwarded-For', '2001:db8:85a3:8d3:1319:8a2e:370:7348')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'severity': 'high',
             'rule': 'X-Forwarded-For',
             'message': 'Header should not be returned'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-Forwarded-For'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Forwarded-For'))
 
     def test_x_generator_ko(self):
-        headers = self.add_or_modify_header('X-Generator', 'Drupal 7 (http://drupal.org)')
-        expected_report_item = {
+        headers = super().add_or_modify_header('X-Generator', 'Drupal 7 (http://drupal.org)')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'severity': 'high',
             'rule': 'X-Generator',
             'message': 'Header should not be returned'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-Generator'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Generator'))
 
     def test_x_powered_by_ko(self):
-        headers = self.add_or_modify_header('X-Powered-By', 'ASP.NET')
-        expected_report_item = {
+        headers = super().add_or_modify_header('X-Powered-By', 'ASP.NET')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'severity': 'high',
             'rule': 'X-Powered-By',
             'message': 'Header should not be returned'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-Powered-By'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-Powered-By'))
 
     def test_x_xss_protection_not_present_ko(self):
-        headers = self.delete_header('X-XSS-Protection')
-        expected_report_item = {
+        headers = super().delete_header('X-XSS-Protection')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'X-XSS-Protection',
             'severity': 'high',
             'message': 'Header not included in response',
-            'expected': ['0'],
-            'delimiter': ';'
+            'expected': ['0']
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-XSS-Protection'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-XSS-Protection'))
 
     def test_x_xss_protection_enable_filter_ko(self):
-        headers = self.add_or_modify_header('X-XSS-Protection', '1; mode=block')
-        expected_report_item = {
+        headers = super().add_or_modify_header('X-XSS-Protection', '1; mode=block')
+
+        report = super().process_test(headers=headers)
+        expected = {
             'rule': 'X-XSS-Protection',
             'severity': 'high',
             'message': 'Value does not match security policy',
             'expected': ['0'],
-            'delimiter': ';',
             'value': '1; mode=block'
         }
-
-        self.process_test(headers=headers, status_code=200)
-        self.assertIn(expected_report_item, self.instance.report,
-                      msg=self.build_error_message(self.instance.report, expected_report=[expected_report_item], rule='X-XSS-Protection'))
+        self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'X-XSS-Protection'))

--- a/tests/test_resources/custom_rules.yml
+++ b/tests/test_resources/custom_rules.yml
@@ -1,13 +1,8 @@
 Headers:
     Content-Security-Policy:
         Required: True
-        Enforce: False
-        Value:
     X-Powered-By:
         Required: True
-        Enforce: False
-        Value:
     New-Invented-Header:
         Required: True
-        Enforce: True
-        Value:
+        Value: required-value

--- a/tests/test_resources/custom_rules_merged.yml
+++ b/tests/test_resources/custom_rules_merged.yml
@@ -1,85 +1,58 @@
 Headers:
+    Cache-Control:
+        Required: True
+        Value:
+            - no-store
+            - max-age=0
     Content-Security-Policy:
         Required: True
-        Enforce: False
-        Value:
-    X-XSS-Protection:
+    Pragma:
         Required: True
-        Enforce: True
         Value:
-            - 0
-    Server:
-        Required: False
-        Enforce: False
-        Value:
-    Strict-Transport-Security:
-        Required: True
-        Enforce: True
-        Value:
-            - max-age=31536000; includeSubDomains
-    X-Frame-Options:
-        Required: True
-        Enforce: True
-        Value:
-            - SAMEORIGIN
-            - DENY
-    X-Content-Type-Options:
-        Required: True
-        Enforce: True
-        Value:
-            - nosniff
-    Set-Cookie:
-        Required: Optional
-        Enforce: False
-        Value:
-        Must-Contain:
-            - HttpOnly
-            - Secure
+            - no-cache
     Referrer-Policy:
         Required: True
-        Enforce: False
-        Delimiter: ','
-        Value:
         Must-Contain-One:
             - strict-origin
             - strict-origin-when-cross-origin
             - no-referrer
-    Cache-Control:
-        Required: True
-        Enforce: True
-        Delimiter: ','
-        Value:
-            - no-store, max-age=0
-    Pragma:
-        Required: True
-        Enforce: True
-        Value:
-            - no-cache
-    X-Powered-By:
-        Required: True
-        Enforce: False
-        Value:
-    X-AspNet-Version:
+    Server:
         Required: False
-        Enforce: False
+    Set-Cookie:
+        Required: Optional
+        Must-Contain:
+            - HttpOnly
+            - Secure
+    Strict-Transport-Security:
+        Required: True
         Value:
-    X-Generator:
-        Required: False
-        Enforce: False
-        Value:
+            - max-age=31536000
+            - includeSubDomains
     User-Agent:
         Required: False
-        Enforce: False
-        Value:
-    X-Forwarded-For:
+    X-AspNet-Version:
         Required: False
-        Enforce: False
-        Value:
     X-Client-IP:
         Required: False
-        Enforce: False
+    X-Content-Type-Options:
+        Required: True
         Value:
+            - nosniff
+    X-Forwarded-For:
+        Required: False
+    X-Frame-Options:
+        Required: True
+        Value-One-Of:
+            - DENY
+            - SAMEORIGIN
+    X-Generator:
+        Required: False
+    X-Powered-By:
+        Required: True
+    X-XSS-Protection:
+        Required: True
+        Value:
+            - 0
     New-Invented-Header:
         Required: True
-        Enforce: True
-        Value:
+        Value: required-value

--- a/tests/test_resources/custom_rules_merged.yml
+++ b/tests/test_resources/custom_rules_merged.yml
@@ -8,11 +8,10 @@ Headers:
         Required: True
     Pragma:
         Required: True
-        Value:
-            - no-cache
+        Value: no-cache
     Referrer-Policy:
         Required: True
-        Must-Contain-One:
+        Value-Any-Of:
             - strict-origin
             - strict-origin-when-cross-origin
             - no-referrer
@@ -36,8 +35,7 @@ Headers:
         Required: False
     X-Content-Type-Options:
         Required: True
-        Value:
-            - nosniff
+        Value: nosniff
     X-Forwarded-For:
         Required: False
     X-Frame-Options:
@@ -51,8 +49,7 @@ Headers:
         Required: True
     X-XSS-Protection:
         Required: True
-        Value:
-            - 0
+        Value: 0
     New-Invented-Header:
         Required: True
         Value: required-value

--- a/tests/test_resources/default_rules.yml
+++ b/tests/test_resources/default_rules.yml
@@ -17,11 +17,10 @@ Headers:
         - self
   Pragma:
     Required: true
-    Value:
-    - no-cache
+    Value: no-cache
   Referrer-Policy:
     Required: true
-    Must-Contain-One:
+    Value-Any-Of:
     - strict-origin
     - strict-origin-when-cross-origin
     - no-referrer
@@ -45,8 +44,7 @@ Headers:
     Required: false
   X-Content-Type-Options:
     Required: true
-    Value:
-    - nosniff
+    Value: nosniff
   X-Forwarded-For:
     Required: false
   X-Frame-Options:
@@ -60,5 +58,4 @@ Headers:
     Required: false
   X-XSS-Protection:
     Required: true
-    Value:
-    - 0
+    Value: 0

--- a/tests/test_resources/default_rules.yml
+++ b/tests/test_resources/default_rules.yml
@@ -1,87 +1,64 @@
 Headers:
+  Cache-Control:
+    Required: true
+    Value:
+    - no-store
+    - max-age=0
   Content-Security-Policy:
     Required: true
-    Enforce: false
-    Value: null
-    Must-Contain-One:
-    - default-src 'none'
-    - default-src 'self'
     Must-Avoid:
     - unsafe-inline
     - unsafe-eval
-  X-XSS-Protection:
+    Directives:
+      default-src:
+        Required: true
+        Value-One-Of:
+        - none
+        - self
+  Pragma:
     Required: true
-    Enforce: true
     Value:
-    - 0
-  Server:
-    Required: false
-    Enforce: false
-    Value: null
-  Strict-Transport-Security:
-    Required: true
-    Enforce: true
-    Value:
-    - max-age=31536000; includeSubDomains
-  X-Frame-Options:
-    Required: true
-    Enforce: true
-    Value:
-    - SAMEORIGIN
-    - DENY
-  X-Content-Type-Options:
-    Required: true
-    Enforce: true
-    Value:
-    - nosniff
-  Set-Cookie:
-    Required: Optional
-    Enforce: false
-    Value: null
-    Must-Contain:
-    - HttpOnly
-    - Secure
+    - no-cache
   Referrer-Policy:
     Required: true
-    Enforce: false
-    Delimiter: ','
-    Value: null
     Must-Contain-One:
     - strict-origin
     - strict-origin-when-cross-origin
     - no-referrer
-  Cache-Control:
+  Server:
+    Required: false
+  Set-Cookie:
+    Required: Optional
+    Must-Contain:
+    - HttpOnly
+    - Secure
+  Strict-Transport-Security:
     Required: true
-    Enforce: true
-    Delimiter: ','
     Value:
-    - no-store, max-age=0
-  Pragma:
-    Required: true
-    Enforce: true
-    Value:
-    - no-cache
-  X-Powered-By:
-    Required: false
-    Enforce: false
-    Value: null
-  X-AspNet-Version:
-    Required: false
-    Enforce: false
-    Value: null
-  X-Generator:
-    Required: false
-    Enforce: false
-    Value: null
+    - max-age=31536000
+    - includeSubDomains
   User-Agent:
     Required: false
-    Enforce: false
-    Value: null
-  X-Forwarded-For:
+  X-AspNet-Version:
     Required: false
-    Enforce: false
-    Value: null
   X-Client-IP:
     Required: false
-    Enforce: false
-    Value: null
+  X-Content-Type-Options:
+    Required: true
+    Value:
+    - nosniff
+  X-Forwarded-For:
+    Required: false
+  X-Frame-Options:
+    Required: true
+    Value-One-Of:
+    - DENY
+    - SAMEORIGIN
+  X-Generator:
+    Required: false
+  X-Powered-By:
+    Required: false
+  X-XSS-Protection:
+    Required: true
+    Value:
+    - 0

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -26,7 +26,7 @@ class TestCli(unittest2.TestCase):
     @mock.patch('drheader.cli.Drheader')
     def test_compare_should_analyse_headers(self, drheader_mock, load_rules_mock):
         drheader_instance = drheader_mock.return_value
-        drheader_instance.report = self.mock_report
+        drheader_instance.reporter.report = self.mock_report
         load_rules_mock.return_value = self.mock_rules
 
         with tempfile.NamedTemporaryFile() as tmp:
@@ -45,7 +45,7 @@ class TestCli(unittest2.TestCase):
     @mock.patch('drheader.cli.Drheader')
     def test_compare_invalid_format_should_raise_exception_and_exit(self, drheader_mock, load_rules_mock):
         drheader_instance = drheader_mock.return_value
-        drheader_instance.report = self.mock_report
+        drheader_instance.reporter.report = self.mock_report
         load_rules_mock.return_value = self.mock_rules
 
         with tempfile.NamedTemporaryFile() as tmp:
@@ -61,7 +61,7 @@ class TestCli(unittest2.TestCase):
     @mock.patch('drheader.cli.Drheader')
     def test_scan_single_should_analyse_target_url(self, drheader_mock, load_rules_mock):
         drheader_instance = drheader_mock.return_value
-        drheader_instance.report = self.mock_report
+        drheader_instance.reporter.report = self.mock_report
         load_rules_mock.return_value = self.mock_rules
 
         runner = CliRunner()
@@ -73,7 +73,7 @@ class TestCli(unittest2.TestCase):
     @mock.patch('drheader.cli.Drheader')
     def test_scan_single_with_json_flag_should_output_json(self, drheader_mock, load_rules_mock):
         drheader_instance = drheader_mock.return_value
-        drheader_instance.report = self.mock_report
+        drheader_instance.reporter.report = self.mock_report
         load_rules_mock.return_value = self.mock_rules
 
         runner = CliRunner()
@@ -87,7 +87,7 @@ class TestCli(unittest2.TestCase):
     @mock.patch('drheader.cli.Drheader')
     def test_scan_single_with_junit_flag_should_write_junit_report(self, drheader_mock, load_rules_mock, junit_mock):
         drheader_instance = drheader_mock.return_value
-        drheader_instance.report = self.mock_report
+        drheader_instance.reporter.report = self.mock_report
         load_rules_mock.return_value = self.mock_rules
 
         runner = CliRunner()
@@ -99,7 +99,7 @@ class TestCli(unittest2.TestCase):
     @mock.patch('drheader.cli.Drheader')
     def test_scan_bulk_should_read_json_file(self, drheader_mock, load_rules_mock):
         drheader_instance = drheader_mock.return_value
-        drheader_instance.report = self.mock_report
+        drheader_instance.reporter.report = self.mock_report
         load_rules_mock.return_value = self.mock_rules
 
         with tempfile.NamedTemporaryFile() as tmp:
@@ -118,7 +118,7 @@ class TestCli(unittest2.TestCase):
     @mock.patch('drheader.cli.Drheader')
     def test_scan_bulk_should_read_txt_file(self, drheader_mock, load_rules_mock):
         drheader_instance = drheader_mock.return_value
-        drheader_instance.report = self.mock_report
+        drheader_instance.reporter.report = self.mock_report
         load_rules_mock.return_value = self.mock_rules
 
         with tempfile.NamedTemporaryFile() as tmp:
@@ -137,7 +137,7 @@ class TestCli(unittest2.TestCase):
     @mock.patch('drheader.cli.Drheader')
     def test_scan_bulk_invalid_format_should_raise_exception_and_exit(self, drheader_mock, load_rules_mock):
         drheader_instance = drheader_mock.return_value
-        drheader_instance.report = self.mock_report
+        drheader_instance.reporter.report = self.mock_report
         load_rules_mock.return_value = self.mock_rules
 
         with tempfile.NamedTemporaryFile() as tmp:

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -22,46 +22,56 @@ class TestUtilsFunctions(unittest2.TestCase):
         with open(os.path.join(os.path.dirname(__file__), '../test_resources/custom_rules_merged.yml')) as f:
             self.custom_rules_merged = yaml.safe_load(f.read())
 
-    def test_parse_policy_should_handle_standalone_directive(self):
+    def test_parse_policy__standalone_directive__ok(self):
         policy = 'session_id=74839222; Secure'
         directives_list = parse_policy(policy, ';', '=')
 
         self.assertIn('Secure', directives_list)
 
-    def test_parse_policy_should_handle_key_value_directive(self):
+    def test_parse_policy__key_value_directive__ok(self):
         policy = 'session_id=74839222; Secure'
         directives_list = parse_policy(policy, ';', '=')
 
         expected = KeyValueDirective('session_id', ['74839222'], '74839222')
         self.assertIn(expected, directives_list)
 
-    def test_parse_policy_should_list_all_values_in_key_value_directive(self):
-        policy = "default-src 'none'; script-src https: 'unsafe-inline'"
-        directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ')
-
-        expected = KeyValueDirective('script-src', ['https:', "'unsafe-inline'"], "https: 'unsafe-inline'")
-        self.assertIn(expected, directives_list)
-
-    def test_parse_policy_should_handle_repeated_delimiters(self):
+    def test_parse_policy__repeated_delimiters__ok(self):
         policy = "default-src 'none';;  ;;   script-src   'self'   'unsafe-inline';;"
         directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ')
 
         expected = KeyValueDirective('script-src', ["'self'", "'unsafe-inline'"], "  'self'   'unsafe-inline'")
         self.assertIn(expected, directives_list)
 
-    def test_parse_policy_keys_only_should_return_only_keys(self):
+    def test_parse_policy__key_value_directive__should_extract_all_values(self):
+        policy = "default-src 'none'; script-src https: 'unsafe-inline'"
+        directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ')
+
+        expected = KeyValueDirective('script-src', ['https:', "'unsafe-inline'"], "https: 'unsafe-inline'")
+        self.assertIn(expected, directives_list)
+
+    def test_parse_policy__strip_items__should_strip_from_values(self):
+        policy = "default-src 'none'; script-src 'self' 'unsafe-inline'"
+        directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ', strip_items='\'')
+
+        expected = KeyValueDirective('script-src', ['self', 'unsafe-inline'], "'self' 'unsafe-inline'")
+        self.assertIn(expected, directives_list)
+
+    def test_parse_policy__keys_only__should_return_only_keys_and_standalone_directives(self):
         policy = "default-src 'none'; script-src https: 'unsafe-inline'; upgrade-insecure-requests"
         directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ', keys_only=True)
 
         expected = ['default-src', 'script-src', 'upgrade-insecure-requests']
         self.assertCountEqual(expected, directives_list)
 
-    def test_parse_policy_should_remove_strip_values(self):
-        policy = "default-src 'none'; script-src 'self' 'unsafe-inline'"
-        directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ', strip_items='\'')
+    def test_parse_policy__key_values_only__should_return_only_key_value_directives(self):
+        policy = "default-src 'none'; script-src https: 'unsafe-inline'; upgrade-insecure-requests"
+        directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ', key_values_only=True)
 
-        expected = KeyValueDirective('script-src', ['self', 'unsafe-inline'], "'self' 'unsafe-inline'")
-        self.assertIn(expected, directives_list)
+        expected = [
+            KeyValueDirective(key='default-src', value=["'none'"], raw_value="'none'"),
+            KeyValueDirective(key='script-src', value=['https:', "'unsafe-inline'"], raw_value="https: 'unsafe-inline'")
+        ]
+        self.assertCountEqual(expected, directives_list)
 
     def test_load_rules_should_load_default_rules_when_no_rules_file_is_provided(self):
         rules = load_rules()

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -4,11 +4,12 @@
 """Tests for `utils.py` file."""
 
 import os
-import yaml
-import unittest2
-import responses
 
-from drheader.utils import load_rules, get_rules_from_uri
+import responses
+import unittest2
+import yaml
+
+from drheader.utils import load_rules, get_rules_from_uri, parse_policy, KeyValueDirective
 
 
 class TestUtilsFunctions(unittest2.TestCase):
@@ -20,6 +21,47 @@ class TestUtilsFunctions(unittest2.TestCase):
             self.custom_rules = yaml.safe_load(f.read())
         with open(os.path.join(os.path.dirname(__file__), '../test_resources/custom_rules_merged.yml')) as f:
             self.custom_rules_merged = yaml.safe_load(f.read())
+
+    def test_parse_policy_should_handle_standalone_directive(self):
+        policy = 'session_id=74839222; Secure'
+        directives_list = parse_policy(policy, ';', '=')
+
+        self.assertIn('Secure', directives_list)
+
+    def test_parse_policy_should_handle_key_value_directive(self):
+        policy = 'session_id=74839222; Secure'
+        directives_list = parse_policy(policy, ';', '=')
+
+        expected = KeyValueDirective('session_id', ['74839222'], '74839222')
+        self.assertIn(expected, directives_list)
+
+    def test_parse_policy_should_list_all_values_in_key_value_directive(self):
+        policy = "default-src 'none'; script-src https: 'unsafe-inline'"
+        directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ')
+
+        expected = KeyValueDirective('script-src', ['https:', "'unsafe-inline'"], "https: 'unsafe-inline'")
+        self.assertIn(expected, directives_list)
+
+    def test_parse_policy_should_handle_repeated_delimiters(self):
+        policy = "default-src 'none';;  ;;   script-src   'self'   'unsafe-inline';;"
+        directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ')
+
+        expected = KeyValueDirective('script-src', ["'self'", "'unsafe-inline'"], "  'self'   'unsafe-inline'")
+        self.assertIn(expected, directives_list)
+
+    def test_parse_policy_keys_only_should_return_only_keys(self):
+        policy = "default-src 'none'; script-src https: 'unsafe-inline'; upgrade-insecure-requests"
+        directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ', keys_only=True)
+
+        expected = ['default-src', 'script-src', 'upgrade-insecure-requests']
+        self.assertCountEqual(expected, directives_list)
+
+    def test_parse_policy_should_remove_strip_values(self):
+        policy = "default-src 'none'; script-src 'self' 'unsafe-inline'"
+        directives_list = parse_policy(policy, ';', ' ', value_delimiter=' ', strip_items='\'')
+
+        expected = KeyValueDirective('script-src', ['self', 'unsafe-inline'], "'self' 'unsafe-inline'")
+        self.assertIn(expected, directives_list)
 
     def test_load_rules_should_load_default_rules_when_no_rules_file_is_provided(self):
         rules = load_rules()

--- a/tests/unit_tests/test_validator.py
+++ b/tests/unit_tests/test_validator.py
@@ -16,7 +16,7 @@ class TestValidator(unittest2.TestCase):
     def assert_report_items_equal(self, expected_report_item, observed_report_item, msg=None):
         does_validate = True
 
-        for field, value in vars(expected_report_item).items():
+        for field in expected_report_item._asdict():
             expected = getattr(expected_report_item, field)
             observed = getattr(observed_report_item, field)
             if not expected == observed:

--- a/tests/unit_tests/test_validator.py
+++ b/tests/unit_tests/test_validator.py
@@ -1,8 +1,11 @@
+from unittest import mock
+
 import unittest2
 from requests.structures import CaseInsensitiveDict
 
 from drheader import validator
 from drheader.report import ReportItem, ErrorType
+from drheader.utils import KeyValueDirective
 
 
 class TestValidator(unittest2.TestCase):
@@ -22,146 +25,259 @@ class TestValidator(unittest2.TestCase):
         if not does_validate:
             raise self.failureException(msg)
 
-    def test_validate_value_unexpected_items_in_header_value_ko(self):
+    def test_validate_value__ok(self):
         config = CaseInsensitiveDict({'required': True, 'value': ['no-store', 'max-age=0']})
-        header_value = 'private, no-store, max-age=0'
+
+        response = validator.validate_value(config, 'no-store, max-age=0', 'cache-control')
+        self.assertIsNone(response)
+
+    def test_validate_value__unexpected_item_in_header_value__ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value': ['no-store', 'max-age=0']})
+        header_value = 'no-store, max-age=0, must-revalidate'
 
         response = validator.validate_value(config, header_value, 'cache-control')
         expected = ReportItem('high', ErrorType.VALUE, 'cache-control', value=header_value, expected=['no-store', 'max-age=0'], delimiter=',')
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
-    def test_validate_value_missing_items_from_header_value_ko(self):
-        config = CaseInsensitiveDict({'required': True, 'value': ['no-store', 'max-age=0']})
-        header_value = 'no-store'
+    def test_validate_value__missing_item_from_header_value__ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value': ['max-age=31536000', 'includesubdomains']})
+        header_value = 'max-age=31536000'
 
-        response = validator.validate_value(config, header_value, 'cache-control')
-        expected = ReportItem('high', ErrorType.VALUE, 'cache-control', value=header_value, expected=['no-store', 'max-age=0'], delimiter=',')
+        response = validator.validate_value(config, header_value, 'strict-transport-security')
+        expected = ReportItem('high', ErrorType.VALUE, 'strict-transport-security', value=header_value, expected=['max-age=31536000', 'includesubdomains'], delimiter=';')
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
-    def test_validate_value_one_of_non_matching_header_value_ko(self):
-        config = CaseInsensitiveDict({'required': True, 'value-one-of': ['DENY', 'SAMEORIGIN']})
-        header_value = 'ALLOW-FROM https://example.com'
+    def test_validate_value_any_of__ok(self):
+        config = CaseInsensitiveDict({'required': True, 'value-any-of': ['no-referrer', 'same-origin', 'strict-origin']})
+
+        response = validator.validate_value_any_of(config, 'no-referrer, same-origin', 'referrer-policy')
+        self.assertIsNone(response)
+
+    def test_validate_value_any_of__non_permitted_item_in_header_value__ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value-any-of': ['no-referrer', 'same-origin', 'strict-origin']})
+        header_value = 'no-referrer, strict-origin-when-cross-origin'
+
+        response = validator.validate_value_any_of(config, header_value, 'referrer-policy')
+        expected = ReportItem('high', ErrorType.VALUE_ANY, 'referrer-policy', value=header_value, expected=['no-referrer', 'same-origin', 'strict-origin'], delimiter=',', anomalies=['strict-origin-when-cross-origin'])
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_value_one_of__ok(self):
+        config = CaseInsensitiveDict({'required': True, 'value-one-of': ['deny', 'sameorigin']})
+
+        response = validator.validate_value_one_of(config, 'deny', 'x-frame-options')
+        self.assertIsNone(response)
+
+    def test_validate_value_one_of__non_permitted_header_value__ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value-one-of': ['deny', 'sameorigin']})
+        header_value = 'allow-from https://example.com'
 
         response = validator.validate_value_one_of(config, header_value, 'x-frame-options')
-        expected = ReportItem('high', ErrorType.VALUE, 'x-frame-options', value=header_value, expected_one=['DENY', 'SAMEORIGIN'])
+        expected = ReportItem('high', ErrorType.VALUE_ONE, 'x-frame-options', value=header_value, expected=['deny', 'sameorigin'])
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
-    def test_validate_value_one_of_additional_items_in_header_value_ko(self):
-        config = CaseInsensitiveDict({'required': True, 'value-one-of': ['DENY', 'SAMEORIGIN']})
-        header_value = 'DENY SAMEORIGIN'
+    def test_validate_value_one_of__too_many_items_in_header_value__ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value-one-of': ['deny', 'sameorigin']})
+        header_value = 'deny sameorigin'
 
         response = validator.validate_value_one_of(config, header_value, 'x-frame-options')
-        expected = ReportItem('high', ErrorType.VALUE, 'x-frame-options', value=header_value, expected_one=['DENY', 'SAMEORIGIN'])
+        expected = ReportItem('high', ErrorType.VALUE_ONE, 'x-frame-options', value=header_value, expected=['deny', 'sameorigin'])
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
-    def test_validate_must_avoid_standalone_directive_ko(self):
-        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['unsafe-url']})
-        header_value = 'unsafe-url'
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid__standalone_directive__ok(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['no-cache', 'private', 'public']})
+        parse_policy_mock.return_value = ['no-store', 'max-age']
 
-        response = validator.validate_must_avoid(config, header_value, 'referrer-policy')[0]
-        expected = ReportItem('medium', ErrorType.AVOID, 'referrer-policy', value=header_value, avoid=['unsafe-url'], anomaly='unsafe-url')
+        response = validator.validate_must_avoid(config, 'no-store, max-age=0', 'cache-control')
+        self.assertIsNone(response)
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid__standalone_directive__ko(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['no-cache', 'private', 'public']})
+        header_value = 'no-cache, max-age=0'
+        parse_policy_mock.return_value = ['no-cache', 'max-age']
+
+        response = validator.validate_must_avoid(config, header_value, 'cache-control')
+        expected = ReportItem('medium', ErrorType.AVOID, 'cache-control', value=header_value, avoid=['no-cache', 'private', 'public'], anomalies=['no-cache'])
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
-    def test_validate_must_avoid_key_value_directive_ko(self):
-        config = CaseInsensitiveDict({'required': 'optional', 'must-avoid': ['SameSite=None']})
-        header_value = 'sid=47383373; HttpOnly; SameSite=None'
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid__key_for_key_value_directive__ok(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['expires', 'max-age']})
+        parse_policy_mock.return_value = ['sid', 'httponly', 'secure']
 
-        response = validator.validate_must_avoid(config, header_value, 'set-cookie')[0]
-        expected = ReportItem('medium', ErrorType.AVOID, 'set-cookie', value=header_value, avoid=['SameSite=None'], anomaly='SameSite=None')
+        response = validator.validate_must_avoid(config, 'sid=47383373; httponly; secure', 'set-cookie')
+        self.assertIsNone(response)
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid__key_for_key_value_directive__ko(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['expires', 'max-age']})
+        header_value = 'sid=47383373; httponly; secure; max-age=2592000'
+        parse_policy_mock.return_value = ['sid', 'httponly', 'secure', 'max-age']
+
+        response = validator.validate_must_avoid(config, header_value, 'set-cookie')
+        expected = ReportItem('medium', ErrorType.AVOID, 'set-cookie', value=header_value, avoid=['expires', 'max-age'], anomalies=['max-age'])
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
-    def test_validate_must_avoid_key_for_key_value_directive_ko(self):
-        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['ALLOW-FROM']})
-        header_value = 'ALLOW-FROM https://example.com'
-
-        response = validator.validate_must_avoid(config, header_value, 'x-frame-options')[0]
-        expected = ReportItem('medium', ErrorType.AVOID, 'x-frame-options', value=header_value, avoid=['ALLOW-FROM'], anomaly='ALLOW-FROM')
-        self.assertEqual(expected, response, msg='The report items are not equal:\n')
-
-    def test_validate_must_avoid_for_policy_header_standalone_directive_ko(self):
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid_for_policy_header__standalone_directive__ok(self, parse_policy_mock):
         config = CaseInsensitiveDict({'required': True, 'must-avoid': ['block-all-mixed-content']})
-        header_value = "default-src 'none'; upgrade-insecure-requests; block-all-mixed-content"
+        parse_policy_mock.return_value = [KeyValueDirective(key='default-src', value=['none'], raw_value="'none'")]
+
+        response = validator.validate_must_avoid(config, "default-src 'none'", 'content-security-policy')
+        self.assertEqual(0, len(response))
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid_for_policy_header__standalone_directive__ko(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['block-all-mixed-content']})
+        header_value = "upgrade-insecure-requests; block-all-mixed-content"
+        parse_policy_mock.return_value = ['upgrade-insecure-requests', 'block-all-mixed-content']
 
         response = validator.validate_must_avoid(config, header_value, 'content-security-policy')[0]
-        expected = ReportItem('medium', ErrorType.AVOID, 'content-security-policy', value=header_value, avoid=['block-all-mixed-content'], anomaly='block-all-mixed-content')
+        expected = ReportItem('medium', ErrorType.AVOID, 'content-security-policy', value=header_value, avoid=['block-all-mixed-content'], anomalies=['block-all-mixed-content'])
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
-    def test_validate_must_avoid_for_policy_header_key_for_key_value_directive_ko(self):
-        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['script-src']})
-        header_value = "default-src 'none'; script-src https://example.com"
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid_for_policy_header__key_for_key_value_directive__ok(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['frame-src']})
+        parse_policy_mock.return_value = [KeyValueDirective(key='default-src', value=['none'], raw_value="'none'")]
+
+        response = validator.validate_must_avoid(config, "default-src 'none'", 'content-security-policy')
+        self.assertEqual(0, len(response))
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid_for_policy_header__key_for_key_value_directive__ko(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['frame-src']})
+        header_value = "default-src 'none'; frame-src https://example.com"
+        parse_policy_mock.return_value = [
+            KeyValueDirective(key='default-src', value=['none'], raw_value="'none'"),
+            KeyValueDirective(key='frame-src', value=['https://example.com'], raw_value='https://example.com')
+        ]
 
         response = validator.validate_must_avoid(config, header_value, 'content-security-policy')[0]
-        expected = ReportItem('medium', ErrorType.AVOID, 'content-security-policy', value=header_value, avoid=['script-src'], anomaly='script-src')
+        expected = ReportItem('medium', ErrorType.AVOID, 'content-security-policy', value=header_value, avoid=['frame-src'], anomalies=['frame-src'])
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
-    def test_validate_must_avoid_for_policy_header_value_for_key_value_directive_ko(self):
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid_for_policy_header__value_for_key_value_directive__ok(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['unsafe-eval']})
+        parse_policy_mock.return_value = [KeyValueDirective(key='default-src', value=['none'], raw_value="'none'")]
+
+        response = validator.validate_must_avoid(config, "default-src 'none'", 'content-security-policy')
+        self.assertEqual(0, len(response))
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid_for_policy_header__value_for_key_value_directive__ko(self, parse_policy_mock):
         config = CaseInsensitiveDict({'required': True, 'must-avoid': ['unsafe-eval']})
         header_value = "default-src 'none'; script-src 'unsafe-eval'"
+        parse_policy_mock.return_value = [
+            KeyValueDirective(key='default-src', value=['none'], raw_value="'none'"),
+            KeyValueDirective(key='script-src', value=['unsafe-eval'], raw_value="'unsafe-eval'")
+        ]
 
         response = validator.validate_must_avoid(config, header_value, 'content-security-policy')[0]
-        expected = ReportItem('medium', ErrorType.AVOID, 'content-security-policy', directive='script-src', value="'unsafe-eval'", avoid=['unsafe-eval'], anomaly='unsafe-eval')
+        expected = ReportItem('medium', ErrorType.AVOID, 'content-security-policy', directive='script-src', value="'unsafe-eval'", avoid=['unsafe-eval'], anomalies=['unsafe-eval'])
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
-    def test_validate_must_avoid_for_policy_header_should_return_all_non_compliant_directives(self):
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_avoid_for_policy_header__should_return_all_non_compliant_directives(self, parse_policy_mock):
         config = CaseInsensitiveDict({'required': True, 'must-avoid': ['unsafe-inline']})
-        header_value = "default-src 'none'; script-src 'unsafe-inline'; object-src 'unsafe-inline'"
+        parse_policy_mock.return_value = [
+            KeyValueDirective(key='default-src', value=['none'], raw_value="'none'"),
+            KeyValueDirective(key='script-src', value=['unsafe-inline'], raw_value="'unsafe-inline'"),
+            KeyValueDirective(key='object-src', value=['unsafe-inline'], raw_value="'unsafe-inline'")
+        ]
 
-        response = validator.validate_must_avoid(config, header_value, 'content-security-policy')
-
-        self.assertEqual(2, len(response))
+        response = validator.validate_must_avoid(config, "default-src 'none'; script-src 'unsafe-inline'; object-src 'unsafe-inline'", 'content-security-policy')
         self.assertEqual('script-src', response[0].directive)
         self.assertEqual('object-src', response[1].directive)
 
-    def test_validate_must_contain_standalone_directive_ko(self):
-        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['secure']})
-        header_value = 'sid=47383373; HttpOnly'
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain__standalone_directive__ok(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['httponly', 'secure']})
+        parse_policy_mock.return_value = ['sid', 'httponly', 'secure']
 
-        response = validator.validate_must_contain(config, header_value, 'set-cookie')[0]
-        expected = ReportItem('medium', ErrorType.CONTAIN, 'set-cookie', value=header_value, expected=['secure'], anomaly='secure', delimiter=';')
-        self.assertEqual(expected, response, msg='The report items are not equal:\n')
-
-    def test_validate_must_contain_key_value_directive_ko(self):
-        config = CaseInsensitiveDict({'required': True, 'must-contain': ['max-age=0']})
-        header_value = 'no-cache, must-revalidate'
-
-        response = validator.validate_must_contain(config, header_value, 'cache-control')[0]
-        expected = ReportItem('medium', ErrorType.CONTAIN, 'cache-control', value=header_value, expected=['max-age=0'], anomaly='max-age=0', delimiter=',')
-        self.assertEqual(expected, response, msg='The report items are not equal:\n')
-
-    def test_validate_must_contain_key_for_key_value_directive_ok(self):
-        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['max-age']})
-        header_value = 'sid=47383373; HttpOnly; Max-Age=0'
-
-        response = validator.validate_must_contain(config, header_value, 'set-cookie')
-        self.assertEqual(0, len(response))
-
-    def test_validate_must_contain_key_for_key_value_directive_ko(self):
-        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['max-age']})
-        header_value = 'sid=47383373; HttpOnly'
-
-        response = validator.validate_must_contain(config, header_value, 'set-cookie')[0]
-        expected = ReportItem('medium', ErrorType.CONTAIN, 'set-cookie', value=header_value, expected=['max-age'], anomaly='max-age', delimiter=';')
-        self.assertEqual(expected, response, msg='The report items are not equal:\n')
-
-    def test_validate_must_contain_one_standalone_directive_ko(self):
-        config = CaseInsensitiveDict({'required': True, 'must-contain-one': ['no-cache', 'must-revalidate']})
-        header_value = 'public, max-age=604800'
-
-        response = validator.validate_must_contain_one(config, header_value, 'cache-control')
-        expected = ReportItem('high', ErrorType.CONTAIN_ONE, 'cache-control', value=header_value, expected_one=['no-cache', 'must-revalidate'])
-        self.assertEqual(expected, response, msg='The report items are not equal:\n')
-
-    def test_validate_must_contain_one_key_for_key_value_directive_ok(self):
-        config = CaseInsensitiveDict({'required': 'optional', 'must-contain-one': ['max-age', 'expires']})
-        header_value = 'sid=47383373; HttpOnly; Max-Age=0'
-
-        response = validator.validate_must_contain_one(config, header_value, 'set-cookie')
+        response = validator.validate_must_contain(config, 'sid=47383373; httponly; secure', 'set-cookie')
         self.assertIsNone(response)
 
-    def test_validate_must_contain_one_key_for_key_value_directive_ko(self):
-        config = CaseInsensitiveDict({'required': 'optional', 'must-contain-one': ['max-age', 'expires']})
-        header_value = 'sid=47383373; HttpOnly'
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain__standalone_directive__ko(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['httponly', 'secure']})
+        header_value = 'sid=47383373; httponly'
+        parse_policy_mock.return_value = ['sid', 'httponly']
+
+        response = validator.validate_must_contain(config, header_value, 'set-cookie')
+        expected = ReportItem('medium', ErrorType.CONTAIN, 'set-cookie', value=header_value, expected=['httponly', 'secure'], anomalies=['secure'], delimiter=';')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain__key_value_directive__ok(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['max-age=0']})
+        parse_policy_mock.return_value = ['sid', 'httponly', 'secure', 'max-age']
+
+        response = validator.validate_must_contain(config, 'sid=47383373; httponly; secure; max-age=0', 'set-cookie')
+        self.assertIsNone(response)
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain__key_value_directive__ko(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['max-age=0']})
+        header_value = 'sid=47383373; httponly; secure'
+        parse_policy_mock.return_value = ['sid', 'httponly', 'secure']
+
+        response = validator.validate_must_contain(config, header_value, 'set-cookie')
+        expected = ReportItem('medium', ErrorType.CONTAIN, 'set-cookie', value=header_value, expected=['max-age=0'], anomalies=['max-age=0'], delimiter=';')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain__key_for_key_value_directive__ok(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['max-age']})
+        parse_policy_mock.return_value = ['sid', 'httponly', 'max-age']
+
+        response = validator.validate_must_contain(config, 'sid=47383373; httponly; max-age=0', 'set-cookie')
+        self.assertIsNone(response)
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain__key_for_key_value_directive__ko(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['max-age']})
+        header_value = 'sid=47383373; httponly'
+        parse_policy_mock.return_value = ['sid', 'httponly']
+
+        response = validator.validate_must_contain(config, header_value, 'set-cookie')
+        expected = ReportItem('medium', ErrorType.CONTAIN, 'set-cookie', value=header_value, expected=['max-age'], anomalies=['max-age'], delimiter=';')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain_one__standalone_directive__ok(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-contain-one': ['no-cache', 'must-revalidate']})
+        parse_policy_mock.return_value = ['public', 'max-age', 'must-revalidate']
+
+        response = validator.validate_must_contain_one(config, 'public, max-age=0, must-revalidate', 'cache-control')
+        self.assertIsNone(response)
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain_one__standalone_directive__ko(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-contain-one': ['no-cache', 'must-revalidate']})
+        header_value = 'public, max-age=604800'
+        parse_policy_mock.return_value = ['public', 'max-age']
+
+        response = validator.validate_must_contain_one(config, header_value, 'cache-control')
+        expected = ReportItem('high', ErrorType.CONTAIN_ONE, 'cache-control', value=header_value, expected=['no-cache', 'must-revalidate'])
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain_one__key_for_key_value_directive__ok(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-contain-one': ['expires', 'max-age']})
+        parse_policy_mock.return_value = ['sid', 'httponly', 'max-age']
+
+        response = validator.validate_must_contain_one(config, 'sid=47383373; httponly; max-age=0', 'set-cookie')
+        self.assertIsNone(response)
+
+    @mock.patch('drheader.validator.parse_policy')
+    def test_validate_must_contain_one__key_for_key_value_directive__ko(self, parse_policy_mock):
+        config = CaseInsensitiveDict({'required': True, 'must-contain-one': ['expires', 'max-age']})
+        header_value = 'sid=47383373; httponly'
+        parse_policy_mock.return_value = ['sid', 'httponly']
 
         response = validator.validate_must_contain_one(config, header_value, 'set-cookie')
-        expected = ReportItem('high', ErrorType.CONTAIN_ONE, 'set-cookie', value=header_value, expected_one=['max-age', 'expires'])
+        expected = ReportItem('high', ErrorType.CONTAIN_ONE, 'set-cookie', value=header_value, expected=['expires', 'max-age'])
         self.assertEqual(expected, response, msg='The report items are not equal:\n')

--- a/tests/unit_tests/test_validator.py
+++ b/tests/unit_tests/test_validator.py
@@ -1,0 +1,167 @@
+import unittest2
+from requests.structures import CaseInsensitiveDict
+
+from drheader import validator
+from drheader.report import ReportItem, ErrorType
+
+
+class TestValidator(unittest2.TestCase):
+
+    def setUp(self):
+        self.addTypeEqualityFunc(ReportItem, self.assert_report_items_equal)
+
+    def assert_report_items_equal(self, expected_report_item, observed_report_item, msg=None):
+        does_validate = True
+
+        for field, value in vars(expected_report_item).items():
+            expected = getattr(expected_report_item, field)
+            observed = getattr(observed_report_item, field)
+            if not expected == observed:
+                msg += f"\tNon-matching values for field '{field}'. Expected: '{expected}' Observed: '{observed}'\n"
+                does_validate = False
+        if not does_validate:
+            raise self.failureException(msg)
+
+    def test_validate_value_unexpected_items_in_header_value_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value': ['no-store', 'max-age=0']})
+        header_value = 'private, no-store, max-age=0'
+
+        response = validator.validate_value(config, header_value, 'cache-control')
+        expected = ReportItem('high', ErrorType.VALUE, 'cache-control', value=header_value, expected=['no-store', 'max-age=0'], delimiter=',')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_value_missing_items_from_header_value_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value': ['no-store', 'max-age=0']})
+        header_value = 'no-store'
+
+        response = validator.validate_value(config, header_value, 'cache-control')
+        expected = ReportItem('high', ErrorType.VALUE, 'cache-control', value=header_value, expected=['no-store', 'max-age=0'], delimiter=',')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_value_one_of_non_matching_header_value_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value-one-of': ['DENY', 'SAMEORIGIN']})
+        header_value = 'ALLOW-FROM https://example.com'
+
+        response = validator.validate_value_one_of(config, header_value, 'x-frame-options')
+        expected = ReportItem('high', ErrorType.VALUE, 'x-frame-options', value=header_value, expected_one=['DENY', 'SAMEORIGIN'])
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_value_one_of_additional_items_in_header_value_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value-one-of': ['DENY', 'SAMEORIGIN']})
+        header_value = 'DENY SAMEORIGIN'
+
+        response = validator.validate_value_one_of(config, header_value, 'x-frame-options')
+        expected = ReportItem('high', ErrorType.VALUE, 'x-frame-options', value=header_value, expected_one=['DENY', 'SAMEORIGIN'])
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_avoid_standalone_directive_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['unsafe-url']})
+        header_value = 'unsafe-url'
+
+        response = validator.validate_must_avoid(config, header_value, 'referrer-policy')[0]
+        expected = ReportItem('medium', ErrorType.AVOID, 'referrer-policy', value=header_value, avoid=['unsafe-url'], anomaly='unsafe-url')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_avoid_key_value_directive_ko(self):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-avoid': ['SameSite=None']})
+        header_value = 'sid=47383373; HttpOnly; SameSite=None'
+
+        response = validator.validate_must_avoid(config, header_value, 'set-cookie')[0]
+        expected = ReportItem('medium', ErrorType.AVOID, 'set-cookie', value=header_value, avoid=['SameSite=None'], anomaly='SameSite=None')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_avoid_key_for_key_value_directive_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['ALLOW-FROM']})
+        header_value = 'ALLOW-FROM https://example.com'
+
+        response = validator.validate_must_avoid(config, header_value, 'x-frame-options')[0]
+        expected = ReportItem('medium', ErrorType.AVOID, 'x-frame-options', value=header_value, avoid=['ALLOW-FROM'], anomaly='ALLOW-FROM')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_avoid_for_policy_header_standalone_directive_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['block-all-mixed-content']})
+        header_value = "default-src 'none'; upgrade-insecure-requests; block-all-mixed-content"
+
+        response = validator.validate_must_avoid(config, header_value, 'content-security-policy')[0]
+        expected = ReportItem('medium', ErrorType.AVOID, 'content-security-policy', value=header_value, avoid=['block-all-mixed-content'], anomaly='block-all-mixed-content')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_avoid_for_policy_header_key_for_key_value_directive_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['script-src']})
+        header_value = "default-src 'none'; script-src https://example.com"
+
+        response = validator.validate_must_avoid(config, header_value, 'content-security-policy')[0]
+        expected = ReportItem('medium', ErrorType.AVOID, 'content-security-policy', value=header_value, avoid=['script-src'], anomaly='script-src')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_avoid_for_policy_header_value_for_key_value_directive_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['unsafe-eval']})
+        header_value = "default-src 'none'; script-src 'unsafe-eval'"
+
+        response = validator.validate_must_avoid(config, header_value, 'content-security-policy')[0]
+        expected = ReportItem('medium', ErrorType.AVOID, 'content-security-policy', directive='script-src', value="'unsafe-eval'", avoid=['unsafe-eval'], anomaly='unsafe-eval')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_avoid_for_policy_header_should_return_all_non_compliant_directives(self):
+        config = CaseInsensitiveDict({'required': True, 'must-avoid': ['unsafe-inline']})
+        header_value = "default-src 'none'; script-src 'unsafe-inline'; object-src 'unsafe-inline'"
+
+        response = validator.validate_must_avoid(config, header_value, 'content-security-policy')
+
+        self.assertEqual(2, len(response))
+        self.assertEqual('script-src', response[0].directive)
+        self.assertEqual('object-src', response[1].directive)
+
+    def test_validate_must_contain_standalone_directive_ko(self):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['secure']})
+        header_value = 'sid=47383373; HttpOnly'
+
+        response = validator.validate_must_contain(config, header_value, 'set-cookie')[0]
+        expected = ReportItem('medium', ErrorType.CONTAIN, 'set-cookie', value=header_value, expected=['secure'], anomaly='secure', delimiter=';')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_contain_key_value_directive_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'must-contain': ['max-age=0']})
+        header_value = 'no-cache, must-revalidate'
+
+        response = validator.validate_must_contain(config, header_value, 'cache-control')[0]
+        expected = ReportItem('medium', ErrorType.CONTAIN, 'cache-control', value=header_value, expected=['max-age=0'], anomaly='max-age=0', delimiter=',')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_contain_key_for_key_value_directive_ok(self):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['max-age']})
+        header_value = 'sid=47383373; HttpOnly; Max-Age=0'
+
+        response = validator.validate_must_contain(config, header_value, 'set-cookie')
+        self.assertEqual(0, len(response))
+
+    def test_validate_must_contain_key_for_key_value_directive_ko(self):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain': ['max-age']})
+        header_value = 'sid=47383373; HttpOnly'
+
+        response = validator.validate_must_contain(config, header_value, 'set-cookie')[0]
+        expected = ReportItem('medium', ErrorType.CONTAIN, 'set-cookie', value=header_value, expected=['max-age'], anomaly='max-age', delimiter=';')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_contain_one_standalone_directive_ko(self):
+        config = CaseInsensitiveDict({'required': True, 'must-contain-one': ['no-cache', 'must-revalidate']})
+        header_value = 'public, max-age=604800'
+
+        response = validator.validate_must_contain_one(config, header_value, 'cache-control')
+        expected = ReportItem('high', ErrorType.CONTAIN_ONE, 'cache-control', value=header_value, expected_one=['no-cache', 'must-revalidate'])
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
+    def test_validate_must_contain_one_key_for_key_value_directive_ok(self):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain-one': ['max-age', 'expires']})
+        header_value = 'sid=47383373; HttpOnly; Max-Age=0'
+
+        response = validator.validate_must_contain_one(config, header_value, 'set-cookie')
+        self.assertIsNone(response)
+
+    def test_validate_must_contain_one_key_for_key_value_directive_ko(self):
+        config = CaseInsensitiveDict({'required': 'optional', 'must-contain-one': ['max-age', 'expires']})
+        header_value = 'sid=47383373; HttpOnly'
+
+        response = validator.validate_must_contain_one(config, header_value, 'set-cookie')
+        expected = ReportItem('high', ErrorType.CONTAIN_ONE, 'set-cookie', value=header_value, expected_one=['max-age', 'expires'])
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')


### PR DESCRIPTION
## Proposed changes

Extensive refactoring. Includes several major changes, lots of more minor changes, a number of bug fixes, and some new functionality for one of the bug fixes. Documented below:

Major Changes:
* The main class has been refactored into separate modules and classes. A new module `validator.py` contains the validation functions, and a new module `report.py` contains classes and methods for generating the report. Methods have also been refactored
* Two new validations, `value-any-of` and `value-one-of`, have been added. The `value` validation has been modified to check for an exact match. See bug fixes
* The `enforce` key has been removed from the rules file. Its value can be inferred from the `value` key
* The `delimiter` key has been removed from the rules file. They are now hard-coded in a JSON file and read from there
* The mechanism for validating cookies has been extended to all the validations

Minor Changes:
* The same granularity available when validating the CSP has been extended to the `feature-policy` header
* The report will aggregate multiple violations for the same rule on the same header into a single report item. Anomalous values are now given as a list
* The report will only include a delimiter in a report item if it's sensible to do so. It's no longer included for `must-avoid` or `must-contain-one` checks, or for report items that have only a single expected value
* The error messages in the report are more descriptive, specifying whether only one, one or more, or all of the expected values should have been returned
* Case is preserved in report items for observed values, expected values and avoid values
* The rules file has been tidied up by removing unnecessary keys, such as `value` for `must-contain` or `must-avoid` checks, and alphabetising it
* All expected, contain and avoid values may now be defined either as a list or a delimited string
* The rule to validate an enforced value has been simplified to use the existing `validate_exists` rule for the exists validation. Duplicated logic has been removed
* The method `validate-must-contain` has been simplified so that the same logic used to validate headers and directives is used to validate cookies. Duplicated logic has been removed
* `must-avoid` validations for policy headers now support keys from key-value directives, and entire key-value directives, as avoid values
* The main class will return an error when neither a headers object, nor a url to retrieve headers from, have been provided
* The fields `anomalies` and `status_code` have been removed from the main class. They were unused
* The `error_types` have been changed from arbitrary numbers to a self-documenting enum
* The rule for `content-security-policy` uses the directive validation mechanism to validate `default-src` rather than `must-contain-one` at the header level. This is better because it won't throw a false positive if there is extraneous space
* The rule for `x-frame-options` now uses the new `value-one-of` validation, as it should only define a single value

Bug Fixes:
* The current implementation of `value` only checks that all items in the header value are permitted by the expected items. For instance, `"strict-transport-security": "includeSubDomains"` would validate against the current implementation. In this PR:
    * `value` now enforces an exact match with all of the expected items
    * `value-any-of` has been added and will enforce an exact match with one or more of the expected items
    * `value-one-of` has been added and will enforce an exact match with exactly one of the expected items
* `must-avoid` validations will now also validate standalone directives in policy headers, such as `block-all-mixed-content` in the CSP. Previously, standalone directives were ignored, and only key-value directives were validated
* The validations will now look for matches against all items in a header value individually, rather than the header value as a whole. This will reduce false positives and false negatives - previously, a cookie named `really_secure_cookie` would have passed the rule requiring the `secure` flag, and similar false positives and negatives could have occurred in the other checks
* Both `must-contain` and `must-contain-one` validations can now be run on the same header. Previously, if both were defined for a single header, only `must-contain-one` would run
* An optional directive that is not present in the headers will not be validated any more. Previously, an optional directive was treated as required
* The method `validate_exists` will no longer run when an item is optional and present in the headers
* The rules file is fully case insensitive. Previously, using `required` in lower case would have thrown a key error

The documentation in `RULES.md` has been updated in line with these changes

## Type of change

What types of changes do you want to introduce to DrHeader?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change 
- [x] Documentation Update
- [x] Test Update
- [x] Rules Update 
- [ ] Other (please describe)

Please ensure your pull request adheres to the following guidelines:
- [ ] A Github Issue that explains the work.
- [ ] The changes are in a branch that is reasonably up to date
- [ ] Tests are provided to reasonably cover new or altered functionality.
- [ ] Documentation is provided for the new or altered functionality.
- [ ] You have the legal right to give us this code.
- [ ] You have adhered to the CoC

## Link to the github issue 

https://github.com/Santandersecurityresearch/DrHeader/issues/

## Tests you have added 

Unit tests for validator methods - test_validator.py
Unit tests for the parse_policy method in utils.py
Integration tests for `value-any-of` and `value-one-of`

## Tests you have altered

testclass.method_name()

## Anything Else 

I've tried to keep it as backward-compatible as possible, but there are some potential breaking changes:

* If someone was providing a value for `value`, but `enforce` was false, this will now run a validation. But this scenario would be improper configuration of the rules anyway, as the value key is meaningless if `enforce` is false
* If someone provided an expected, contain or avoid value as a string defining multiple items in the first element of a list, this will break. It needs to be either a string or a list
* If someone is providing a value for `status_code` when creating a drheader instance, they will get an error due to an unexpected argument
* If someone is using the `value` validation to only check for a partial match, it will fail as it now requires a whole match. The fix would be to change `value` to `value-any-of` or `value-one-of`, depending on the use case

Thanks for getting this far !
