### PR TITLE
Option to preserve order when validating

### DIFF
--- a/drheader/rules.yml
+++ b/drheader/rules.yml
@@ -20,7 +20,7 @@ Headers:
         Value: no-cache
     Referrer-Policy:
         Required: True
-        Value-Any-Of:
+        Value-One-Of:
             - strict-origin
             - strict-origin-when-cross-origin
             - no-referrer

--- a/drheader/validator.py
+++ b/drheader/validator.py
@@ -90,10 +90,16 @@ def validate_value(config, item_value, header, directive=None):
         validation_items = [item.strip(delimiters.get('strip_items')) for item in item_value.split(delimiter)]
         raw_value = item_value
 
-    validation_items = {str(item).strip().lower() for item in validation_items}
     expected = _get_expected_values(config, 'value', delimiter)
 
-    if validation_items != {item.lower() for item in expected}:
+    if config.get('preserve-order'):
+        validation_items = [str(item).strip().lower() for item in validation_items]
+        expected_lower = [item.lower() for item in expected]
+    else:
+        validation_items = {str(item).strip().lower() for item in validation_items}
+        expected_lower = {item.lower() for item in expected}
+
+    if validation_items != expected_lower:
         severity = config.get('severity', 'high')
         return ReportItem(severity, Error.VALUE, header, directive, raw_value, expected=expected, delimiter=delimiter)
 

--- a/tests/integration_tests/test_rules.py
+++ b/tests/integration_tests/test_rules.py
@@ -80,8 +80,7 @@ class TestDefaultRules(TestBase):
             'rule': 'Referrer-Policy',
             'severity': 'high',
             'message': 'Header not included in response',
-            'expected': ['strict-origin', 'strict-origin-when-cross-origin', 'no-referrer'],
-            'delimiter': ','
+            'expected': ['strict-origin', 'strict-origin-when-cross-origin', 'no-referrer']
         }
         self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Referrer-Policy'))
 
@@ -92,11 +91,9 @@ class TestDefaultRules(TestBase):
         expected = {
             'rule': 'Referrer-Policy',
             'severity': 'high',
-            'message': 'Value does not match security policy. At least one of the expected items was expected',
+            'message': 'Value does not match security policy. Exactly one of the expected items was expected',
             'expected': ['strict-origin', 'strict-origin-when-cross-origin', 'no-referrer'],
-            'value': 'same-origin',
-            'anomalies': ['same-origin'],
-            'delimiter': ','
+            'value': 'same-origin'
         }
         self.assertIn(expected, report, msg=super().build_error_message(report, expected, 'Referrer-Policy'))
 

--- a/tests/test_resources/custom_rules_merged.yml
+++ b/tests/test_resources/custom_rules_merged.yml
@@ -11,7 +11,7 @@ Headers:
         Value: no-cache
     Referrer-Policy:
         Required: True
-        Value-Any-Of:
+        Value-One-Of:
             - strict-origin
             - strict-origin-when-cross-origin
             - no-referrer

--- a/tests/test_resources/default_rules.yml
+++ b/tests/test_resources/default_rules.yml
@@ -20,7 +20,7 @@ Headers:
     Value: no-cache
   Referrer-Policy:
     Required: true
-    Value-Any-Of:
+    Value-One-Of:
     - strict-origin
     - strict-origin-when-cross-origin
     - no-referrer

--- a/tests/unit_tests/test_validator.py
+++ b/tests/unit_tests/test_validator.py
@@ -47,6 +47,14 @@ class TestValidator(unittest2.TestCase):
         expected = ReportItem('high', ErrorType.VALUE, 'strict-transport-security', value=header_value, expected=['max-age=31536000', 'includesubdomains'], delimiter=';')
         self.assertEqual(expected, response, msg='The report items are not equal:\n')
 
+    def test_validate_value__enforced_order_not_correct__ko(self):
+        config = CaseInsensitiveDict({'required': True, 'value': ['no-referrer', 'strict-origin-when-cross-origin'], 'preserve-order': True})
+        header_value = 'strict-origin-when-cross-origin, no-referrer'
+
+        response = validator.validate_value(config, header_value, 'referrer-policy')
+        expected = ReportItem('high', ErrorType.VALUE, 'referrer-policy', value=header_value, expected=['no-referrer', 'strict-origin-when-cross-origin'], delimiter=',')
+        self.assertEqual(expected, response, msg='The report items are not equal:\n')
+
     def test_validate_value_any_of__ok(self):
         config = CaseInsensitiveDict({'required': True, 'value-any-of': ['no-referrer', 'same-origin', 'strict-origin']})
 


### PR DESCRIPTION
## Proposed changes

There are certain scenarios when the order of items in a header matters, such as when specifying a fallback referrer policy: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#specify_a_fallback_policy

This PR adds the option to enforce the order of items when running a `value` validation, by specifying `preserve-order` in the rule.

## Type of change

What types of changes do you want to introduce to DrHeader?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation Update
- [ ] Test Update
- [ ] Rules Update 
- [ ] Other (please describe)

Please ensure your pull request adheres to the following guidelines:
- [ ] A Github Issue that explains the work.
- [ ] The changes are in a branch that is reasonably up to date
- [ ] Tests are provided to reasonably cover new or altered functionality.
- [ ] Documentation is provided for the new or altered functionality.
- [ ] You have the legal right to give us this code.
- [ ] You have adhered to the CoC

## Link to the github issue 

https://github.com/Santandersecurityresearch/DrHeader/issues/

## Tests you have added 

test_validator.test_validate_value__enforced_order_not_correct__ko() 

## Tests you have altered

testclass.method_name()

## Anything Else 


Thanks for getting this far !
